### PR TITLE
all: remove some dead code

### DIFF
--- a/db.go
+++ b/db.go
@@ -24,7 +24,6 @@ type Link struct {
 	Created  time.Time
 	LastEdit time.Time // when the link was last edited
 	Owner    string    // user@domain
-	Clicks   int       `json:",omitempty"` // number of times this link has been served
 }
 
 // ClickStats is the number of clicks a set of links have received in a given


### PR DESCRIPTION
go/.export doesn't include click data anymore since we switched over to sqlite.  Remove that code as well as the Link.Clicks field.  Remove old /_/export redirect, since we've long since moved off of using it.