### PR TITLE
Update README.md to fix a change in flyctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ destination="/root"
   ``` sh
   $ flyctl apps create FLY_APP_NAME
   $ flyctl volumes create FLY_VOLUME_NAME
-  $ flyctl secrets create TS_AUTHKEY=tskey-auth-<key>
+  $ flyctl secrets set TS_AUTHKEY=tskey-auth-<key>
   $ flyctl deploy
   ```
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ destination="/root"
   Then run the commands with the [flyctl CLI].
 
   ``` sh
-  $ flyctl create app FLY_APP_NAME
+  $ flyctl apps create FLY_APP_NAME
   $ flyctl volumes create FLY_VOLUME_NAME
   $ flyctl secrets create TS_AUTHKEY=tskey-auth-<key>
   $ flyctl deploy


### PR DESCRIPTION
flyctl has updated: `Command "create" is deprecated, replaced by 'apps create'`