### PR TITLE
add TrimSuffix to the function map

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -353,6 +353,7 @@ type expandEnv struct {
 var expandFuncMap = texttemplate.FuncMap{
 	"PathEscape":  url.PathEscape,
 	"QueryEscape": url.QueryEscape,
+	"TrimSuffix": strings.TrimSuffix,
 }
 
 // expandLink returns the expanded long URL to redirect to, executing any

--- a/golink_test.go
+++ b/golink_test.go
@@ -68,6 +68,12 @@ func TestExpandLink(t *testing.T) {
 			remainder: "a+b",
 			want:      "http://host.com/a%2Bb",
 		},
+		{
+			name:      "template-with-trimsuffix-func",
+			long:      `http://host.com/{{TrimSuffix .Path "/"}}`,
+			remainder: "a/",
+			want:      "http://host.com/a",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Adds strings.TrimSuffix to the function map, enabling it to be used in URL definitions.

This accompanies the discussion in #9 and is motivated by the browser misfeature of my Safari instance, which fails to recognize a local domain URL as a URL unless it has a trailing slash. The intended use of this function is to trim that trailing slash.

(There is most certainly some more elegant way to do this, but as a start this is the one-line fix suggested by @willnorris that lets me make forward progress.)