### PR TITLE
add support for browser bar search keyword

### DIFF
--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -1,0 +1,8 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+<ShortName>localhost</ShortName>
+<Description>localhost url redirector</Description>
+<InputEncoding>UTF-8</InputEncoding>
+<Image width="16" height="16" type="image/x-icon">https://github.com/favicon.ico</Image>
+<Url type="text/html" method="get" template="http://localhost:8080/{searchTerms}"/>
+<moz:SearchForm>http://localhost:8080/</moz:SearchForm>
+</OpenSearchDescription>

--- a/tmpl/base.html
+++ b/tmpl/base.html
@@ -4,6 +4,7 @@
   <title>go/</title>
   <link rel="stylesheet" href="/.static/base.css">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="search" type="application/opensearchdescription+xml" title="searchTitle" href="/.opensearch" />
 </head>
 <body class="flex flex-col min-h-screen">
   <div class="bg-gray-100 border-b border-gray-200 pt-4 pb-2 mb-6">

--- a/tmpl/opensearch.xml
+++ b/tmpl/opensearch.xml
@@ -1,0 +1,8 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>{{.Hostname}}</ShortName>
+  <Description>Private shortlinks on your tailnet</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/png">http://{{.Hostname}}/.static/favicon.png</Image>
+  <Url type="text/html" method="get" template="http://{{.Hostname}}/{searchTerms}"/>
+  <moz:SearchForm>http://{{.Hostname}}/</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
Proof of concept of adding support for browser based keyword search. This will require additional templating to fill in the xml with the actual `hostname`

This will help with safari (and chrome), as it will add the hostname as a keyword search.

Easy to test out using: `go run ./cmd/golink -dev-listen :8080`

In the below example you could `localhost test` and it would resolve to `localhost/test` which would then golink to the configured place.

<img width="299" alt="image" src="https://user-images.githubusercontent.com/1746413/205415755-d31fc474-1c87-420a-bd34-978839be5ad4.png">

docs: 
https://developer.mozilla.org/en-US/docs/Web/OpenSearch#autodiscovery_of_search_plugins