### PR TITLE
Add flag that makes link editable by any user on tailnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+*.db

--- a/db.go
+++ b/db.go
@@ -19,11 +19,12 @@ import (
 
 // Link is the structure stored for each go short link.
 type Link struct {
-	Short    string // the "foo" part of http://go/foo
-	Long     string // the target URL or text/template pattern to run
-	Created  time.Time
-	LastEdit time.Time // when the link was last edited
-	Owner    string    // user@domain
+	Short            string // the "foo" part of http://go/foo
+	Long             string // the target URL or text/template pattern to run
+	Created          time.Time
+	LastEdit         time.Time // when the link was last edited
+	Owner            string    // user@domain
+	GloballyEditable bool      // when set, link is editable by everyone on the tailnet
 }
 
 // ClickStats is the number of clicks a set of links have received in a given
@@ -67,14 +68,14 @@ func NewSQLiteDB(f string) (*SQLiteDB, error) {
 // The caller owns the returned values.
 func (s *SQLiteDB) LoadAll() ([]*Link, error) {
 	var links []*Link
-	rows, err := s.db.Query("SELECT Short, Long, Created, LastEdit, Owner FROM Links")
+	rows, err := s.db.Query("SELECT Short, Long, Created, LastEdit, Owner, GloballyEditable FROM Links")
 	if err != nil {
 		return nil, err
 	}
 	for rows.Next() {
 		link := new(Link)
 		var created, lastEdit int64
-		err := rows.Scan(&link.Short, &link.Long, &created, &lastEdit, &link.Owner)
+		err := rows.Scan(&link.Short, &link.Long, &created, &lastEdit, &link.Owner, &link.GloballyEditable)
 		if err != nil {
 			return nil, err
 		}
@@ -93,8 +94,8 @@ func (s *SQLiteDB) LoadAll() ([]*Link, error) {
 func (s *SQLiteDB) Load(short string) (*Link, error) {
 	link := new(Link)
 	var created, lastEdit int64
-	row := s.db.QueryRow("SELECT Short, Long, Created, LastEdit, Owner FROM Links WHERE ID = ?1 LIMIT 1", linkID(short))
-	err := row.Scan(&link.Short, &link.Long, &created, &lastEdit, &link.Owner)
+	row := s.db.QueryRow("SELECT Short, Long, Created, LastEdit, Owner, GloballyEditable FROM Links WHERE ID = ?1 LIMIT 1", linkID(short))
+	err := row.Scan(&link.Short, &link.Long, &created, &lastEdit, &link.Owner, &link.GloballyEditable)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = fs.ErrNotExist
@@ -108,7 +109,7 @@ func (s *SQLiteDB) Load(short string) (*Link, error) {
 
 // Save saves a Link.
 func (s *SQLiteDB) Save(link *Link) error {
-	result, err := s.db.Exec("INSERT OR REPLACE INTO Links (ID, Short, Long, Created, LastEdit, Owner) VALUES (?, ?, ?, ?, ?, ?)", linkID(link.Short), link.Short, link.Long, link.Created.Unix(), link.LastEdit.Unix(), link.Owner)
+	result, err := s.db.Exec("INSERT OR REPLACE INTO Links (ID, Short, Long, Created, LastEdit, Owner, GloballyEditable) VALUES (?, ?, ?, ?, ?, ?, ?)", linkID(link.Short), link.Short, link.Long, link.Created.Unix(), link.LastEdit.Unix(), link.Owner, link.GloballyEditable)
 	if err != nil {
 		return err
 	}

--- a/schema.sql
+++ b/schema.sql
@@ -4,7 +4,8 @@ CREATE TABLE IF NOT EXISTS Links (
 	Long     TEXT    NOT NULL DEFAULT "",
 	Created  INTEGER NOT NULL DEFAULT (strftime('%s', 'now')), -- unix seconds
 	LastEdit INTEGER NOT NULL DEFAULT (strftime('%s', 'now')), -- unix seconds
-	Owner	 TEXT    NOT NULL DEFAULT ""
+	Owner	 TEXT    NOT NULL DEFAULT "",
+	GloballyEditable INTEGER NOT NULL DEFAULT FALSE
 );
 
 CREATE TABLE IF NOT EXISTS Stats (

--- a/tmpl/detail.html
+++ b/tmpl/detail.html
@@ -17,6 +17,8 @@
 
       <label for=owner class="text-sm font-bold block mt-4">Owner</label>
       <input id=owner name=owner required type=text size=25 placeholder="Owner" value="{{.Link.Owner}}"{{if not .Editable}} disabled{{end}} class="p-2 rounded-md border-gray-300 placeholder:text-gray-400 disabled:bg-gray-100">
+      <input id=globally-editable name=globally-editable type=checkbox {{if .Link.GloballyEditable}} checked{{end}} class="p-2 rounded-md border-gray-300 disabled:bg-gray-100">
+      <label for=globally-editable>Editable by anyone</label>
 
       <dl>
         <dt class="text-sm font-bold mt-6">Date Created</dt>


### PR DESCRIPTION
One way to implement #18 – adding a checkbox during link creation that the owner can tick in case they want the link to be editable by other users on the tailnet. Not terribly happy about the name, open to suggestions there.

Off by default. Here's what it looks like:
<img width="724" alt="image" src="https://user-images.githubusercontent.com/4654623/205503091-c1a096ba-2867-4eb7-b37e-885400767df0.png">

No formal tests right now. `serveDetail` is not really set up for tests given it uses `currentUser()`.
I'm happy to put some time into making these handlers little easier to test with `httptest` and test this new field in a followup PR is that's the direction you'd like to take.

Tested manually:
First, create link as user `foo`:
```
> curl -XPOST -F short=cool-link -F long=https://tailscale.com -F owner=foo@example.com localhost:9999
{"Short":"cool-link","Long":"https://tailscale.com","Created":"2022-12-04T16:42:18Z","LastEdit":"2022-12-04T16:45:10.407439Z","Owner":"foo@example.com","GloballyEditable":false}
```

Now, replace the const dev user in `currentUser`:
```
> sed -i '' -e 's/foo@example.com/foo2@example.com/g' golink.go
```

Try changing the link:
```
> curl -XPOST -F short=cool-link -F long=https://tailscale.net -F owner=foo2@example.com localhost:9999
not your link; owned by foo@example.com
```

Swap back to foo, and make the link globally editable:
```
> curl -XPOST -F short=cool-link -F long=https://tailscale.com -F globally-editable=on localhost:9999
{"Short":"cool-link","Long":"https://tailscale.com","Created":"2022-12-04T16:42:18Z","LastEdit":"2022-12-04T16:48:41.522668Z","Owner":"foo@example.com","GloballyEditable":true}
```

Swap back to foo2, and try editing the link:
```
> curl -XPOST -F short=cool-link -F long=https://tailscale.net localhost:9999
{"Short":"cool-link","Long":"https://tailscale.net","Created":"2022-12-04T16:42:18Z","LastEdit":"2022-12-04T16:50:06.034046Z","Owner":"foo2@example.com","GloballyEditable":false}
```

Also taking the liberty to piggyback a gitignore change so that me and future contributors can `git add .` without worrying about sqlite files, happy to take that out if you feel it shouldn't be there.
 