### PR TITLE
add support for resolving links locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,7 @@ Only links that don't already exist in the database will be added.
     golink -snapshot links.json
 
 [JSON lines]: https://jsonlines.org/
+
+You can also resolve links locally using a snapshot file:
+
+    golink -resolve-from-backup links.json go/link


### PR DESCRIPTION
We technically don't even need the `-resolve-from-backup` flag.  Otherwise, callers would just need to specify:

```
golink -sqlitefile ":memory:" -snapshot /path/to/snapshot.json linkname
```

As implemented, it just sets those two flags and enforces that a link to be resolved is specified.  Maybe that's still worth keeping?

Fixes #15 