### PR TITLE
db: use canonical link short name in stats

### DIFF
--- a/db.go
+++ b/db.go
@@ -124,6 +124,15 @@ func (s *SQLiteDB) Save(link *Link) error {
 
 // LoadStats returns click stats for links.
 func (s *SQLiteDB) LoadStats() (ClickStats, error) {
+	allLinks, err := s.LoadAll()
+	if err != nil {
+		return nil, err
+	}
+	linkmap := make(map[string]string, len(allLinks)) // map ID => Short
+	for _, link := range allLinks {
+		linkmap[linkID(link.Short)] = link.Short
+	}
+
 	rows, err := s.db.Query("SELECT ID, sum(Clicks) FROM Stats GROUP BY ID")
 	if err != nil {
 		return nil, err
@@ -136,7 +145,8 @@ func (s *SQLiteDB) LoadStats() (ClickStats, error) {
 		if err != nil {
 			return nil, err
 		}
-		stats[id] = clicks
+		short := linkmap[id]
+		stats[short] = clicks
 	}
 	return stats, rows.Err()
 }

--- a/db_test.go
+++ b/db_test.go
@@ -60,7 +60,7 @@ func Test_SQLiteDB_SaveLoadStats(t *testing.T) {
 	// preload some links
 	links := []*Link{
 		{Short: "a"},
-		{Short: "b"},
+		{Short: "B-c"},
 	}
 	for _, link := range links {
 		if err := db.Save(link); err != nil {
@@ -68,15 +68,17 @@ func Test_SQLiteDB_SaveLoadStats(t *testing.T) {
 		}
 	}
 
-	// stats to record and then retrieve
+	// Stats to record and then retrieve.
+	// Stats to store do not need to be their canonical short name,
+	// but returned stats always should be.
 	stats := []ClickStats{
 		{"a": 1},
-		{"b": 1},
-		{"a": 1, "b": 2},
+		{"b-c": 1},
+		{"a": 1, "bc": 2},
 	}
 	want := ClickStats{
-		"a": 2,
-		"b": 3,
+		"a":   2,
+		"B-c": 3,
 	}
 
 	for _, s := range stats {


### PR DESCRIPTION
When loading stats from the database, map IDs back to their canonical short name, which is what we want to show in the frontend.  This is only called once on cold start, so performance of loading all links isn't a big concern.

Fixes #13