### PR TITLE
Dockerfile: use musl variant for go build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/go:1.19 as build
+FROM cgr.dev/chainguard/go:1.19-musl as build
 
 WORKDIR /work
 


### PR DESCRIPTION
Most of the details are in https://github.com/chainguard-images/images/issues/182.  At the end of last year, Chainguard switched from alpine+musl to wolfi+glibc as their default for their go images.  These new images are only built for linux/amd64 and linux/arm64.  We'd build for linux/arm/v7 as well in order to support older raspberry pis, which is only available in the musl images.

Fixes #42