### PR TITLE
golink: add endpoint to delete link

### DIFF
--- a/db.go
+++ b/db.go
@@ -122,6 +122,28 @@ func (s *SQLiteDB) Save(link *Link) error {
 	return nil
 }
 
+// Delete removes a Link using its short name.
+func (s *SQLiteDB) Delete(short string) error {
+	result, err := s.db.Exec("DELETE FROM Links WHERE ID = ?", linkID(short))
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows != 1 {
+		return fmt.Errorf("expected to affect 1 row, affected %d", rows)
+	}
+
+	_, err = s.db.Exec("DELETE FROM Stats WHERE ID = ?", linkID(short))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // LoadStats returns click stats for links.
 func (s *SQLiteDB) LoadStats() (ClickStats, error) {
 	allLinks, err := s.LoadAll()

--- a/golink.go
+++ b/golink.go
@@ -198,6 +198,9 @@ var (
 	// allTmpl is the template used by the http://go/.all page
 	allTmpl *template.Template
 
+	// deleteTmpl is the template used after a link has been deleted.
+	deleteTmpl *template.Template
+
 	// opensearchTmpl is the template used by the http://go/.opensearch page
 	opensearchTmpl *template.Template
 )
@@ -219,6 +222,7 @@ func init() {
 	successTmpl = template.Must(template.ParseFS(embeddedFS, "tmpl/base.html", "tmpl/success.html"))
 	helpTmpl = template.Must(template.ParseFS(embeddedFS, "tmpl/base.html", "tmpl/help.html"))
 	allTmpl = template.Must(template.ParseFS(embeddedFS, "tmpl/base.html", "tmpl/all.html"))
+	deleteTmpl = template.Must(template.ParseFS(embeddedFS, "tmpl/base.html", "tmpl/delete.html"))
 	opensearchTmpl = template.Must(template.ParseFS(embeddedFS, "tmpl/opensearch.xml"))
 }
 
@@ -546,7 +550,7 @@ func serveDelete(w http.ResponseWriter, r *http.Request) {
 	}
 	deleteLinkStats(link)
 
-	http.Redirect(w, r, "/", http.StatusFound)
+	deleteTmpl.Execute(w, link)
 }
 
 // serveSave handles requests to save or update a Link.  Both short name and

--- a/tmpl/delete.html
+++ b/tmpl/delete.html
@@ -1,0 +1,18 @@
+{{ define "main" }}
+    <h2 class="text-xl font-bold pb-2">Link Deleted</h2>
+
+    <form method="POST" action="/">
+      <div class="flex flex-wrap">
+        <div class="flex">
+          <label for=short class="flex my-2 px-2 items-center bg-gray-100 border border-r-0 border-gray-300 rounded-l-md text-gray-700">http://go/</label>
+          <input id=short name=short required type=text size=15 placeholder="shortname" value="{{.Short}}" pattern="\w[\w\-\.]*" title="Must start with letter or number; may contain letters, numbers, dashes, and periods."
+            class="p-2 my-2 rounded-r-md border-gray-300 placeholder:text-gray-400 disabled:bg-gray-100">
+          <span class="flex m-2 items-center">&rarr;</span>
+        </div>
+        <input name=long required type=text size=40 placeholder="https://destination-url" value="{{.Long}}" class="p-2 my-2 mr-2 max-w-full rounded-md border-gray-300 placeholder:text-gray-400 disabled:bg-gray-100">
+      </div>
+
+      <p class="pt-4">Deleted this by mistake? Click below to recreate the same link.</p>
+      <button type=submit class="py-2 px-4 my-2 rounded-md bg-blue-500 border-blue-500 text-white hover:bg-blue-600 hover:border-blue-600">Create</button>
+    </form>
+{{ end }}

--- a/tmpl/detail.html
+++ b/tmpl/detail.html
@@ -26,7 +26,8 @@
         <dd>{{.Link.LastEdit.Format "Jan _2, 2006 3:04pm MST"}}</dd>
       </dl>
 
-      <button type=submit class="py-2 px-4 my-2 rounded-md bg-blue-500 border-blue-500 text-white hover:bg-blue-600 hover:border-blue-600">Update</button>
+      <button type=submit name="action" value="save" class="py-2 px-4 my-2 rounded-md bg-blue-500 border-blue-500 text-white hover:bg-blue-600 hover:border-blue-600">Update</button>
+      <button type=submit name="action" value="delete" class="py-2 px-4 my-2 rounded-md border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100">Delete</button>
     </form>
 
     {{ else }}

--- a/tmpl/detail.html
+++ b/tmpl/detail.html
@@ -27,6 +27,7 @@
       </dl>
 
       <button type=submit class="py-2 px-4 my-2 rounded-md bg-blue-500 border-blue-500 text-white hover:bg-blue-600 hover:border-blue-600">Update</button>
+      <a href="/.delete/{{.Link.Short}}" class="py-2 px-4 my-2 rounded-md text-gray-700 hover:underline">Delete</a>
     </form>
 
     {{ else }}

--- a/tmpl/detail.html
+++ b/tmpl/detail.html
@@ -26,8 +26,7 @@
         <dd>{{.Link.LastEdit.Format "Jan _2, 2006 3:04pm MST"}}</dd>
       </dl>
 
-      <button type=submit name="action" value="save" class="py-2 px-4 my-2 rounded-md bg-blue-500 border-blue-500 text-white hover:bg-blue-600 hover:border-blue-600">Update</button>
-      <button type=submit name="action" value="delete" class="py-2 px-4 my-2 rounded-md border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100">Delete</button>
+      <button type=submit class="py-2 px-4 my-2 rounded-md bg-blue-500 border-blue-500 text-white hover:bg-blue-600 hover:border-blue-600">Update</button>
     </form>
 
     {{ else }}

--- a/tmpl/home.html
+++ b/tmpl/home.html
@@ -9,7 +9,7 @@
         <span class="flex m-2 items-center">&rarr;</span>
       </div>
       <input name=long required type=text size=40 placeholder="https://destination-url"{{if .Short}} autofocus{{end}} class="p-2 my-2 mr-2 max-w-full rounded-md border-gray-300 placeholder:text-gray-400">
-      <button type=submit class="py-2 px-4 my-2 rounded-md bg-blue-500 border-blue-500 text-white hover:bg-blue-600 hover:border-blue-600">Create</button>
+      <button type=submit name="action" value="save" class="py-2 px-4 my-2 rounded-md bg-blue-500 border-blue-500 text-white hover:bg-blue-600 hover:border-blue-600">Create</button>
     </form>
     <p class="text-sm text-gray-500"><a class="text-blue-600 hover:underline" href="/.help">Help and advanced options</a></p>
 

--- a/tmpl/home.html
+++ b/tmpl/home.html
@@ -9,7 +9,7 @@
         <span class="flex m-2 items-center">&rarr;</span>
       </div>
       <input name=long required type=text size=40 placeholder="https://destination-url"{{if .Short}} autofocus{{end}} class="p-2 my-2 mr-2 max-w-full rounded-md border-gray-300 placeholder:text-gray-400">
-      <button type=submit name="action" value="save" class="py-2 px-4 my-2 rounded-md bg-blue-500 border-blue-500 text-white hover:bg-blue-600 hover:border-blue-600">Create</button>
+      <button type=submit class="py-2 px-4 my-2 rounded-md bg-blue-500 border-blue-500 text-white hover:bg-blue-600 hover:border-blue-600">Create</button>
     </form>
     <p class="text-sm text-gray-500"><a class="text-blue-600 hover:underline" href="/.help">Help and advanced options</a></p>
 


### PR DESCRIPTION
To delete a link, go to its page in .detail and click on the "Delete" button. Stats for the deleted link are removed as well.

Fixes #16.

edit: changed to delete by visiting the `/.delete/{link}` endpoint instead.