### PR TITLE
golink: add .all page to display all existing links

### DIFF
--- a/tmpl/all.html
+++ b/tmpl/all.html
@@ -1,0 +1,30 @@
+{{ define "main" }}
+    <h2 class="text-xl font-bold pt-6 pb-2">All Links</h2>
+    <table class="table-auto ">
+      <thead class="border-b border-gray-200 uppercase text-xs text-gray-500 text-left">
+        <tr>
+          <th class="p-2">Link</th>
+          <th class="p-2">Long</th>
+          <th class="p-2">Owner</th>
+          <th class="p-2">Created</th>
+          <th class="p-2">Last Edit</th>
+        </tr>
+      </thead>
+      <tbody>
+      {{ range . }}
+        <tr class="hover:bg-gray-100 group border-b border-gray-200">
+          <td class="flex">
+            <a class="block flex-1 p-2 pr-4 hover:text-blue-500 hover:underline" href="/{{ .Short }}">go/{{ .Short }}</a>
+            <a class="flex items-center px-2 invisible group-hover:visible" title="Link Details" href="/.detail/{{ .Short }}">
+              <svg class="hover:fill-blue-500" xmlns="http://www.w3.org/2000/svg" height="1.3em" viewBox="0 0 24 24" width="1.3em" fill="#000000" stroke-width="2"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg>
+            </a>
+          </td>
+          <td class="p-2">{{ .Long }}</td>
+          <td class="p-2">{{ .Owner }}</td>
+          <td class="p-2">{{ .Created }}</td>
+          <td class="p-2">{{ .LastEdit }}</td>
+        </tr>
+      {{ end }}
+      </tbody>
+    </table>
+{{ end }}


### PR DESCRIPTION
This PR adds a new endpoint at `/.all` to show all available links.