### PR TITLE
include current user resolving link in expandEnv

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -363,7 +363,9 @@ func serveGo(w http.ResponseWriter, r *http.Request) {
 	stats.dirty[link.Short]++
 	stats.mu.Unlock()
 
-	target, err := expandLink(link.Long, expandEnv{Now: time.Now().UTC(), Path: remainder})
+	currentUser, _ := currentUser(r)
+
+	target, err := expandLink(link.Long, expandEnv{Now: time.Now().UTC(), Path: remainder, User: currentUser})
 	if err != nil {
 		log.Printf("expanding %q: %v", link.Long, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -431,6 +433,10 @@ type expandEnv struct {
 	// Path is the remaining path after short name.  For example, in
 	// "http://go/who/amelie", Path is "amelie".
 	Path string
+
+	// User is the current user, if any.
+	// For example, "foo@example.com" or "foo@github".
+	User string
 }
 
 var expandFuncMap = texttemplate.FuncMap{

--- a/golink_test.go
+++ b/golink_test.go
@@ -10,11 +10,12 @@ import (
 
 func TestExpandLink(t *testing.T) {
 	tests := []struct {
-		name      string
-		long      string
-		now       time.Time
-		remainder string
-		want      string
+		name      string    // test name
+		long      string    // long URL for golink
+		now       time.Time // current time
+		user      string    // current user resolving link
+		remainder string    // remainder of URL path after golink name
+		want      string    // expected redirect URL
 	}{
 		{
 			name: "dont-mangle-escapes",
@@ -46,6 +47,12 @@ func TestExpandLink(t *testing.T) {
 			now:  time.Date(2022, 06, 02, 1, 2, 3, 4, time.UTC),
 		},
 		{
+			name: "var-expansions-user",
+			long: `http://host.com/{{.User}}`,
+			user: "foo@example.com",
+			want: "http://host.com/foo@example.com",
+		},
+		{
 			name: "template-no-path",
 			long: "https://calendar.google.com/{{with .Path}}calendar/embed?mode=week&src={{.}}@tailscale.com{{end}}",
 			want: "https://calendar.google.com/",
@@ -58,7 +65,7 @@ func TestExpandLink(t *testing.T) {
 		},
 		{
 			name:      "template-with-pathescape-func",
-			long:      "http://host.com/{{QueryEscape .Path}}",
+			long:      "http://host.com/{{PathEscape .Path}}",
 			remainder: "a/b",
 			want:      "http://host.com/a%2Fb",
 		},
@@ -77,7 +84,7 @@ func TestExpandLink(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := expandLink(tt.long, expandEnv{Now: tt.now, Path: tt.remainder})
+			got, err := expandLink(tt.long, expandEnv{Now: tt.now, Path: tt.remainder, User: tt.user})
 			if err != nil {
 				t.Fatalf("expandLink(%q): %v", tt.long, err)
 			}

--- a/tmpl/help.html
+++ b/tmpl/help.html
@@ -43,10 +43,11 @@ To have more control over how go links are resolved, destination links can use <
 Templates are provided a data structure with the following fields:
 
 <ul>
-  <li><code>.Path</code> is the remaining path value after the short name (without a leading slash). For the link <strong>go/who/amelie</strong>,
-      the value of <code>.Path</code> is <code>amelie</code>.
+  <li><code>.Path</code> is the remaining path value after the short name (without a leading slash).
+    For the link <strong>go/who/amelie</strong>, the value of <code>.Path</code> is <code>amelie</code>.
   <li><code>.Now</code> is a <a href="https://pkg.go.dev/time#Time">time.Time</a> value representing the current date and time.
-      Use <a href="https://pkg.go.dev/time#Time.Format">Time.Format</a> to output date or time in desired format.
+  <li><code>.User</code> is the current user resolving the link.
+    This is the email address of the user or <code>{username}@github</code> for tailnets that use GitHub authentication.
 </ul>
 
 Templates also have access to the following template functions:


### PR DESCRIPTION
Add "User" to the expansion environment for links.  The intent here it support personalized go links such as:

  go/mycal => https://calendar.google.com/calendar/embed?src={{.User}}

That's not a terribly interesting example, but there are others I intend to use internally.

There's small risk of this being used to do things like track who clicks what links... 

  go/secret => http://secret-link/?clicked-by={{.User}}

But using go links to do that is kinda boring... any service on your tailnet can already tell who the authenticated user, so this doesn't really reveal anything new.