### PR TITLE
golink: allow -resolve-from-backup to resolve alias links

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -667,5 +667,11 @@ func resolveLink(link string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return expandLink(l.Long, expandEnv{Now: time.Now().UTC(), Path: remainder})
+	dst, err := expandLink(l.Long, expandEnv{Now: time.Now().UTC(), Path: remainder})
+	if err == nil {
+		if u, uErr := url.Parse(dst); uErr == nil && (u.Hostname() == "" || u.Hostname() == *hostname) {
+			dst, err = resolveLink(dst)
+		}
+	}
+	return dst, err
 }

--- a/golink_test.go
+++ b/golink_test.go
@@ -103,6 +103,8 @@ func TestResolveLink(t *testing.T) {
 	}
 	db.Save(&Link{Short: "meet", Long: "https://meet.google.com/lookup/"})
 	db.Save(&Link{Short: "cs", Long: "http://codesearch/{{with .Path}}search?q={{.}}{{end}}"})
+	db.Save(&Link{Short: "m", Long: "http://go/meet"})
+	db.Save(&Link{Short: "chat", Long: "/meet"})
 
 	tests := []struct {
 		link string
@@ -136,6 +138,16 @@ func TestResolveLink(t *testing.T) {
 		{
 			link: "cs/term",
 			want: "http://codesearch/search?q=term",
+		},
+		{
+			// aliased go links with hostname
+			link: "m/foo",
+			want: "https://meet.google.com/lookup/foo",
+		},
+		{
+			// aliased go links without hostname
+			link: "chat/foo",
+			want: "https://meet.google.com/lookup/foo",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
It's not uncommon to have multiple links pointing to the same destination, for example to handle different spellings of a word or because different people created them at different times.

A common best practice is to select one as the "primary" link and point the others to that link as "aliases".  This change updates resolveLink to follow those aliases so that the final destination is returned when using `golink -resolve-from-backup`.