### PR TITLE
go.mod: bump tailscale.com version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	modernc.org/sqlite v1.19.4
 	// Always use a pseudo-version for the tailscale.com module, or else
 	// go's version selection causes problems when pulling golink into corp.
-	tailscale.com v1.40.0
+	tailscale.com v1.1.1-0.20230501211016-c5bf868940d8
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -339,5 +339,5 @@ modernc.org/z v1.7.0 h1:xkDw/KepgEjeizO2sNco+hqYkU12taxQFqPEmgm1GWE=
 nhooyr.io/websocket v1.8.7 h1:usjR2uOr/zjjkVMy0lW+PPohFok7PCow5sDjLgX4P4g=
 nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 software.sslmate.com/src/go-pkcs12 v0.2.0 h1:nlFkj7bTysH6VkC4fGphtjXRbezREPgrHuJG20hBGPE=
-tailscale.com v1.40.0 h1:3guThaC1cCSHQ2nAk0ChQ8D5CCQmfwcQFTUcfpBrKPE=
-tailscale.com v1.40.0/go.mod h1:j5vekUD4eLhLpHl/tNBps25strCOBXyiKUsdR1HhMq8=
+tailscale.com v1.1.1-0.20230501211016-c5bf868940d8 h1:QbnQDg2w9XvrBnIYZiZSRLjTGLgI87cBXON6b5KVqgo=
+tailscale.com v1.1.1-0.20230501211016-c5bf868940d8/go.mod h1:j5vekUD4eLhLpHl/tNBps25strCOBXyiKUsdR1HhMq8=


### PR DESCRIPTION
bump version again, back to the latest commit on main, rather than the latest released version. Otherwise, this causes issues in tailscale's corp repo (sadly).