### PR TITLE
add support for query parameters in go links

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -351,7 +351,7 @@ func serveOpenSearch(w http.ResponseWriter, _ *http.Request) {
 }
 
 func serveGo(w http.ResponseWriter, r *http.Request) {
-	if r.RequestURI == "/" {
+	if r.URL.Path == "/" {
 		switch r.Method {
 		case "GET":
 			serveHome(w, "")
@@ -361,7 +361,7 @@ func serveGo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	short, remainder, _ := strings.Cut(strings.TrimPrefix(r.RequestURI, "/"), "/")
+	short, remainder, _ := strings.Cut(strings.TrimPrefix(r.URL.Path, "/"), "/")
 
 	// redirect {name}+ links to /.detail/{name}
 	if strings.HasSuffix(short, "+") {
@@ -420,7 +420,7 @@ type detailData struct {
 }
 
 func serveDetail(w http.ResponseWriter, r *http.Request) {
-	short := strings.TrimPrefix(r.RequestURI, "/.detail/")
+	short := strings.TrimPrefix(r.URL.Path, "/.detail/")
 
 	link, err := db.Load(short)
 	if errors.Is(err, fs.ErrNotExist) {
@@ -568,7 +568,7 @@ func userExists(ctx context.Context, login string) (bool, error) {
 var reShortName = regexp.MustCompile(`^\w[\w\-\.]*$`)
 
 func serveDelete(w http.ResponseWriter, r *http.Request) {
-	short := strings.TrimPrefix(r.RequestURI, "/.delete/")
+	short := strings.TrimPrefix(r.URL.Path, "/.delete/")
 	if short == "" {
 		http.Error(w, "short required", http.StatusBadRequest)
 		return

--- a/golink_test.go
+++ b/golink_test.go
@@ -51,6 +51,24 @@ func TestServeGo(t *testing.T) {
 			wantLink:    "http://who/",
 		},
 		{
+			name:       "simple link with path",
+			link:       "/who/p",
+			wantStatus: http.StatusFound,
+			wantLink:   "http://who/p",
+		},
+		{
+			name:       "simple link with query",
+			link:       "/who?q",
+			wantStatus: http.StatusFound,
+			wantLink:   "http://who/", // TODO: eventually http://who/?q
+		},
+		{
+			name:       "simple link with path and query",
+			link:       "/who/p?q",
+			wantStatus: http.StatusFound,
+			wantLink:   "http://who/p", // TODO: eventually http://who/p?q
+		},
+		{
 			name:       "user link",
 			link:       "/me",
 			wantStatus: http.StatusFound,


### PR DESCRIPTION
This PR contains three separate commits that incrementally improve handling of query parameters in go links.  It's probably best to review the separately, in order.

Test cases pretty clearly show the kinds of requests this adds support for.

[edit] I removed support for appending the path remainder (in the default case with no go templates) and separately combining the query strings.  That was just too complicated, and was pretty contrived to begin with.  You can still achieve the same by using a go template in the long URL to append the path.

Fixes #77 