### PR TITLE
Allow deletion of unowned links

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -565,6 +565,10 @@ var currentUser = func(r *http.Request) (string, error) {
 func userExists(ctx context.Context, login string) (bool, error) {
 	const userTaggedDevices = "tagged-devices" // owner of tagged devices
 
+	if login == userTaggedDevices {
+		return false, nil
+	}
+
 	if devMode() {
 		// in dev mode, just assume the user exists
 		return true, nil


### PR DESCRIPTION
First of all, thanks for golink!

**Description**
It should be possible to delete links owned by non-existing users (tagged-devices or deleted) in the same ways as it's possible to edit these links.

**Related PRs**
* https://github.com/tailscale/golink/pull/72
* https://github.com/tailscale/golink/pull/74
