### PR TITLE
remove unused input field attribute disabled in details form

### DIFF
--- a/tmpl/detail.html
+++ b/tmpl/detail.html
@@ -6,17 +6,17 @@
       <div class="flex flex-wrap">
         <div class="flex">
           <label for=short class="flex my-2 px-2 items-center bg-gray-100 border border-r-0 border-gray-300 rounded-l-md text-gray-700">http://go/</label>
-          <input id=short name=short required type=text size=15 placeholder="shortname" value="{{.Link.Short}}"{{if not .Editable}} disabled{{end}} pattern="\w[\w\-\.]*" title="Must start with letter or number; may contain letters, numbers, dashes, and periods."
+          <input id=short name=short required type=text size=15 placeholder="shortname" value="{{.Link.Short}}" pattern="\w[\w\-\.]*" title="Must start with letter or number; may contain letters, numbers, dashes, and periods."
             class="p-2 my-2 rounded-r-md border-gray-300 placeholder:text-gray-400 disabled:bg-gray-100">
           <span class="flex m-2 items-center">&rarr;</span>
         </div>
-        <input name=long required type=text size=40 placeholder="https://destination-url" value="{{.Link.Long}}"{{if not .Editable}} disabled{{end}} class="p-2 my-2 mr-2 max-w-full rounded-md border-gray-300 placeholder:text-gray-400 disabled:bg-gray-100">
+        <input name=long required type=text size=40 placeholder="https://destination-url" value="{{.Link.Long}}" class="p-2 my-2 mr-2 max-w-full rounded-md border-gray-300 placeholder:text-gray-400 disabled:bg-gray-100">
       </div>
 
       <p class="text-sm text-gray-500"><a class="text-blue-600 hover:underline" href="/.help">Help and advanced options</a></p>
 
       <label for=owner class="text-sm font-bold block mt-4">Owner</label>
-      <input id=owner name=owner required type=text size=25 placeholder="Owner" value="{{.Link.Owner}}"{{if not .Editable}} disabled{{end}} class="p-2 rounded-md border-gray-300 placeholder:text-gray-400 disabled:bg-gray-100">
+      <input id=owner name=owner required type=text size=25 placeholder="Owner" value="{{.Link.Owner}}" class="p-2 rounded-md border-gray-300 placeholder:text-gray-400 disabled:bg-gray-100">
 
       <dl>
         <dt class="text-sm font-bold mt-6">Date Created</dt>


### PR DESCRIPTION
The detail page of a link only displays the form if the link is editable for the logged in user.

Therefore, it's not necessary to disable the input fields within the form if the link isn't editable.