### PR TITLE
Dockerfile: stop using chainguard go image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/go:1.20 as build
+FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/wolfi-base as build
+RUN apk update && apk add build-base git openssh go-1.20
 
 WORKDIR /work
 


### PR DESCRIPTION
Chainguard is no longer allowing free users to use specific versions of images like go (instead, having to always use "latest"). So instead, we will create our own build image by installing the needed packages on top of the wolfi-base image.

This is one of the recommended approaches in their migration guide: https://www.chainguard.dev/unchained/a-guide-on-how-to-use-chainguard-images-for-public-catalog-tier-users

Fixes #82