### PR TITLE
feat: Add --administrators to manage the instance

### DIFF
--- a/golink_test.go
+++ b/golink_test.go
@@ -133,7 +133,7 @@ func TestServeSave(t *testing.T) {
 		long              string
 		allowUnknownUsers bool
 		currentUser       func(*http.Request) (string, error)
-		adminlist         []string
+		adminList         []string
 		wantStatus        int
 	}{
 		{
@@ -166,7 +166,7 @@ func TestServeSave(t *testing.T) {
 			short:       "link-owned-by-another-user",
 			long:        "/after",
 			currentUser: func(*http.Request) (string, error) { return "bar@example.com", nil },
-			adminlist:   []string{"bar@example.com"},
+			adminList:   []string{"bar@example.com"},
 			wantStatus:  http.StatusOK,
 		},
 		{
@@ -207,11 +207,11 @@ func TestServeSave(t *testing.T) {
 			*allowUnknownUsers = tt.allowUnknownUsers
 			t.Cleanup(func() { *allowUnknownUsers = oldAllowUnknownUsers })
 
-			if tt.adminlist != nil {
-				oldadminlist := adminlist
-				adminlist = tt.adminlist
+			if tt.adminList != nil {
+				oldadminList := adminList
+				adminList = tt.adminList
 				t.Cleanup(func() {
-					adminlist = oldadminlist
+					adminList = oldadminList
 				})
 			}
 
@@ -250,7 +250,7 @@ func TestServeDelete(t *testing.T) {
 		short       string
 		xsrf        string
 		currentUser func(*http.Request) (string, error)
-		adminlist   []string
+		adminList   []string
 		wantStatus  int
 	}{
 		{
@@ -272,7 +272,7 @@ func TestServeDelete(t *testing.T) {
 			name:        "Allow deleting another's link if Admin",
 			short:       "link-owned-by-another-user",
 			currentUser: func(*http.Request) (string, error) { return "bar@example.com", nil },
-			adminlist:   []string{"bar@example.com"},
+			adminList:   []string{"bar@example.com"},
 			xsrf:        xsrf("bar@example.com", "link-owned-by-another-user"),
 			wantStatus:  http.StatusOK,
 		},
@@ -306,11 +306,11 @@ func TestServeDelete(t *testing.T) {
 				})
 			}
 			
-			if tt.adminlist != nil {
-				oldadminlist := adminlist
-				adminlist = tt.adminlist
+			if tt.adminList != nil {
+				oldadminList := adminList
+				adminList = tt.adminList
 				t.Cleanup(func() {
-					adminlist = oldadminlist
+					adminList = oldadminList
 				})
 			}
 			

--- a/golink_test.go
+++ b/golink_test.go
@@ -208,10 +208,10 @@ func TestServeSave(t *testing.T) {
 			t.Cleanup(func() { *allowUnknownUsers = oldAllowUnknownUsers })
 
 			if tt.adminList != nil {
-				oldadminList := adminList
+				oldAdminList := adminList
 				adminList = tt.adminList
 				t.Cleanup(func() {
-					adminList = oldadminList
+					adminList = oldAdminList
 				})
 			}
 
@@ -307,10 +307,10 @@ func TestServeDelete(t *testing.T) {
 			}
 			
 			if tt.adminList != nil {
-				oldadminList := adminList
+				oldAdminList := adminList
 				adminList = tt.adminList
 				t.Cleanup(func() {
-					adminList = oldadminList
+					adminList = oldAdminList
 				})
 			}
 			

--- a/tmpl/all.html
+++ b/tmpl/all.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <h2 class="text-xl font-bold pt-6 pb-2">All Links ({{ len . }} total)</h2>
+    <h2 class="text-xl font-bold pt-6 pb-2">All Links ({{ len .Links }} total)</h2>
     <table class="table-auto w-full max-w-screen-lg">
       <thead class="border-b border-gray-200 uppercase text-xs text-gray-500 text-left">
         <tr class="flex">
@@ -9,7 +9,7 @@
         </tr>
       </thead>
       <tbody>
-      {{ range . }}
+      {{ range .Links }}
         <tr class="flex hover:bg-gray-100 group border-b border-gray-200">
           <td class="flex-1 p-2">
             <div class="flex">

--- a/tmpl/base.html
+++ b/tmpl/base.html
@@ -21,6 +21,7 @@
   </main>
   <footer class="bg-gray-100 border-t border-gray-200 pt-2 pb-2 mt-6">
     <div class="container mx-auto px-4 leading-6 text-right">
+      {{ if .Admins }}<i>Instance Administrators: {{ .Admins }}<br/>{{ end }}
       From the nerds at
       <a href="https://tailscale.com/" class="inline-block align-text-top">
       <svg width="18" height="18" viewBox="0 0 22 22" fill="none" role="img" aria-labelledby="tsTitle" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Usage:
  --administrators=email@domain.ext,email2@domain2.ext,...

This allows, through tailscale's reporting of the logged user, to update or delete golinks generated by everybody else on the same instance.