### PR TITLE
golink: don't modify URL path when resolving link

### DIFF
--- a/golink_test.go
+++ b/golink_test.go
@@ -70,6 +70,12 @@ func TestServeGo(t *testing.T) {
 			wantLink:   "http://who/p?q=1",
 		},
 		{
+			name:       "simple link with double slash in path",
+			link:       "/who/http://host",
+			wantStatus: http.StatusFound,
+			wantLink:   "http://who/http://host",
+		},
+		{
 			name:       "user link",
 			link:       "/me",
 			wantStatus: http.StatusFound,
@@ -105,7 +111,7 @@ func TestServeGo(t *testing.T) {
 
 			r := httptest.NewRequest("GET", tt.link, nil)
 			w := httptest.NewRecorder()
-			serveGo(w, r)
+			serveHandler().ServeHTTP(w, r)
 
 			if w.Code != tt.wantStatus {
 				t.Errorf("serveGo(%q) = %d; want %d", tt.link, w.Code, tt.wantStatus)


### PR DESCRIPTION
Both http.ServeMux as well as the http.Redirect method pass the request URL through `cleanPath` which, among other things, collapses double slashes `//` to a single slash `/`. Most of the time this is fine, since most servers treat those as identical anyway. But some destination servers need the original path unmodified. Since we're just redirecting, we don't need to be concerned with the additional benefits of `cleanPath` such as eliminating `../` path components, since that is the responsibility of the destination server to clean if needed.

This change adds a separate root http.Handler for golink requests. It still uses http.ServeMux for internal endpoints, but serves golinks directly without passing the request through ServeMux. Additionally, this sets the redirect status and Location header directly rather than calling http.Redirect, since that also modifies the URL it is given.

Fixes #89