### PR TITLE
Update github actions workflow for publishing docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,12 +3,12 @@ name: Docker
 on:
   push:
     # push events will publish a new image, so only trigger on main branch or semver tags.
-    branches: [ 'main' ]
-    tags: [ 'v*' ]
+    branches: ["main"]
+    tags: ["v*"]
   pull_request:
     # Run the workflow on pull_request events to ensure we can still build the image.
     # We only publish the image on push events (see if statements in steps below).
-    branches: [ 'main' ]
+    branches: ["main"]
 
 env:
   REGISTRY: ghcr.io
@@ -27,44 +27,44 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Setup Docker buildx
-      uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
-      with:
-        # use buildx v0.9.1 (https://community.fly.io/t/10171/19)
-        version: v0.9.1
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
+        with:
+          # use buildx v0.9.1 (https://community.fly.io/t/10171/19)
+          version: v0.9.1
 
-    - name: Log into registry ${{ env.REGISTRY }}
-      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
-      if: github.event_name == 'push'
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        if: github.event_name == 'push'
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Extract Docker metadata
-      id: meta
-      uses: docker/metadata-action@57396166ad8aefe6098280995947635806a0e6ea # v4.1.1
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@57396166ad8aefe6098280995947635806a0e6ea # v4.1.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-    - name: Build and push Docker image
-      id: build-and-push
-      uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # v3.2.0
-      with:
-        context: .
-        push: ${{ github.event_name == 'push' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        platforms: linux/amd64,linux/arm64,linux/arm/v7
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # v3.2.0
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
 
-    # Sign the Docker image
-    - name: Install cosign
-      if: github.event_name == 'push'
-      uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b #v2.8.1
-    - name: Sign the published Docker image
-      if: github.event_name == 'push'
-      env:
-        COSIGN_EXPERIMENTAL: "true"
-      run: cosign sign ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}
+      # Sign the Docker image
+      - name: Install cosign
+        if: github.event_name == 'push'
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b #v2.8.1
+      - name: Sign the published Docker image
+        if: github.event_name == 'push'
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: cosign sign ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,16 +27,13 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
-        with:
-          # use buildx v0.9.1 (https://community.fly.io/t/10171/19)
-          version: v0.9.1
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         if: github.event_name == 'push'
         with:
           registry: ${{ env.REGISTRY }}
@@ -45,13 +42,13 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@57396166ad8aefe6098280995947635806a0e6ea # v4.1.1
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # v3.2.0
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: .
           push: ${{ github.event_name == 'push' }}
@@ -62,9 +59,7 @@ jobs:
       # Sign the Docker image
       - name: Install cosign
         if: github.event_name == 'push'
-        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b #v2.8.1
+        uses: sigstore/cosign-installer@1fc5bd396d372bee37d608f955b336615edf79c8 #v3.2.0
       - name: Sign the published Docker image
         if: github.event_name == 'push'
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        run: cosign sign ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}
+        run: cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,8 @@ on:
       - main
   pull_request:
     branches:
-      - '*'
-      - 'release-branch/*'
+      - "*"
+      - "release-branch/*"
 
 concurrency:
   group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
The first commit runs the yaml files through prettier to use whatever common formatting it has.

The second commit updates the GitHub actions used for publishing the docker image.  The version of cosign we were using is apparently not published any longer(?) and was [causing errors](https://github.com/tailscale/golink/actions/runs/6872874346).  It also looks like the Fly issue with buildx [has been resolved](https://community.fly.io/t/10171/39), so stop pinning to buildx 0.9.1

Successful test run: https://github.com/willnorris/golink/actions/runs/6872887373