### PR TITLE
golink: use new serveHandler with tsnet

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -177,7 +177,7 @@ func Run() error {
 	}
 
 	log.Printf("Serving http://%s/ ...", *hostname)
-	if err := http.Serve(l80, nil); err != nil {
+	if err := http.Serve(l80, serveHandler()); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
In 46ed42f, I mistakenly only attached the serveHandler to the dev listener, but not tsnet.

Fixes #91