### PR TITLE
golink: set HTTP status after Location header

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -425,8 +425,8 @@ func serveGo(w http.ResponseWriter, r *http.Request) {
 
 	// http.Redirect always cleans the redirect URL, which we don't always want.
 	// Instead, manually set status and Location header.
-	w.WriteHeader(http.StatusFound)
 	w.Header().Set("Location", target.String())
+	w.WriteHeader(http.StatusFound)
 }
 
 // acceptHTML returns whether the request can accept a text/html response.


### PR DESCRIPTION
I didn't think the order mattered (as long as none of the response body had been written), but I guess I was wrong. Currently, it's returning the 302 status, but no Location header. And tests, at least some of which should be passing through this full code path, are passing. I'll look into adding better testing later, but for now this fixes the immediate issue.

Updates #91