### PR TITLE
golink: listen on HTTPS and redirect HTTP traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ If you're using Firefox, you might want to configure two options to make it easy
 ## HTTPS
 
 When golink joins your tailnet it will check to see if HTTPS is enabled and
-begin serving HTTPS traffic if the answer is yes. If HTTPs is enabled golink
+begin serving HTTPS traffic it detects that it is. When HTTPs is enabled golink
 will redirect all requests received by the HTTP endpoint first to their internal
 HTTPS equivalent before redirecting to the external link destination.
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ If you're using Firefox, you might want to configure two options to make it easy
 ## HTTPS
 
 When golink joins your tailnet it will check to see if HTTPS is enabled and
-begin serving HTTPS traffic it detects that it is. When HTTPs is enabled golink
+begin serving HTTPS traffic it detects that it is. When HTTPS is enabled golink
 will redirect all requests received by the HTTP endpoint first to their internal
 HTTPS equivalent before redirecting to the external link destination.
 

--- a/README.md
+++ b/README.md
@@ -146,3 +146,16 @@ If you're using Firefox, you might want to configure two options to make it easy
     with a value of _true_
 
   * if you use HTTPS-Only Mode, [add an exception](https://support.mozilla.org/en-US/kb/https-only-prefs#w_add-exceptions-for-http-websites-when-youre-in-https-only-mode)
+
+## HTTPS
+
+When golink joins your tailnet it will check to see if HTTPS is enabled and
+begin serving HTTPS traffic if the answer is yes. If HTTPs is enabled golink
+will redirect all requests received by the HTTP endpoint first to their internal
+HTTPS equivalent before redirecting to the external link destination.
+
+**NB:** If you use `curl` to interact with the API of a golink instance with HTTPS
+enabled over its HTTP interface you _must_ specify the `-L` flag to follow these
+redirects or else your request will terminate early with an empty response. We
+recommend the use of the `-L` flag in all deployments regardless of current
+HTTPS status to avoid accidental outages should it be enabled in the future.

--- a/golink.go
+++ b/golink.go
@@ -329,7 +329,7 @@ func deleteLinkStats(link *Link) {
 // requests. It redirects all requests to the HTTPs version of the same URL.
 func redirectHandler(hostname string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, (&url.URL{Scheme: "https", Host: hostname, Path: r.URL.Path}).String(), http.StatusMovedPermanently)
+		http.Redirect(w, r, (&url.URL{Scheme: "https", Host: hostname, Path: r.URL.Path}).String(), http.StatusFound)
 	})
 }
 

--- a/golink.go
+++ b/golink.go
@@ -217,7 +217,7 @@ func Run() error {
 		}
 		s := http.Server{
 			Addr:    ":443",
-			Handler: serveHandler(),
+			Handler: HSTS(serveHandler()),
 			TLSConfig: &tls.Config{
 				GetCertificate: localClient.GetCertificate,
 			},
@@ -354,6 +354,15 @@ func redirectHandler(hostname string) http.Handler {
 		path := r.URL.Path
 		newUrl := fmt.Sprintf("https://%s%s", hostname, path)
 		http.Redirect(w, r, newUrl, http.StatusMovedPermanently)
+	})
+}
+
+// HSTS wraps the provided handler and sets Strict-Transport-Security header on
+// all responses.
+func HSTS(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+		h.ServeHTTP(w, r)
 	})
 }
 

--- a/golink.go
+++ b/golink.go
@@ -36,6 +36,7 @@ import (
 	"tailscale.com/ipn"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tsnet"
+	"tailscale.com/util/dnsname"
 )
 
 const defaultHostname = "go"
@@ -341,8 +342,12 @@ func HSTS(h http.Handler) http.Handler {
 		host, found := r.Header["Host"]
 		if found {
 			host := host[0]
-			if strings.Contains(host, ".") {
-				w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+			fqdn, err := dnsname.ToFQDN(host)
+			if err == nil {
+				segCount := fqdn.NumLabels()
+				if segCount > 1 {
+					w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+				}
 			}
 		}
 		h.ServeHTTP(w, r)

--- a/golink.go
+++ b/golink.go
@@ -334,10 +334,17 @@ func redirectHandler(hostname string) http.Handler {
 }
 
 // HSTS wraps the provided handler and sets Strict-Transport-Security header on
-// all responses.
+// responses. It inspects the Host header to ensure we do not specify HSTS
+// response on non fully qualified domain name origins.
 func HSTS(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+		host, found := r.Header["Host"]
+		if found {
+			host := host[0]
+			if strings.Contains(host, ".") {
+				w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+			}
+		}
 		h.ServeHTTP(w, r)
 	})
 }

--- a/tmpl/help.html
+++ b/tmpl/help.html
@@ -114,7 +114,7 @@ Include a "+" after a link to get information about a link without resolving it:
 Visit <a href="/.export">go/.export</a> to export all saved links and their metadata in <a href="https://jsonlines.org/">JSON Lines format</a>.
 This is useful to create data snapshots that can be restored later.
 
-<pre>{{`$ curl go/.export
+<pre>{{`$ curl -L go/.export
 {"Short":"go","Long":"http://go","Created":"2022-05-31T13:04:44.741457796-07:00","LastEdit":"2022-05-31T13:04:44.741457796-07:00","Owner":"amelie@example.com","Clicks":1}
 {"Short":"slack","Long":"https://company.slack.com/{{if .Path}}channels/{{PathEscape .Path}}{{end}}","Created":"2022-06-17T18:05:43.562948451Z","LastEdit":"2022-06-17T18:06:35.811398Z","Owner":"amelie@example.com","Clicks":4}`}}
 </pre>
@@ -122,7 +122,7 @@ This is useful to create data snapshots that can be restored later.
 <p>
 Create a new link by sending a POST request with a <code>short</code> and <code>long</code> value:
 
-<pre>{{`$ curl -d short=cs -d long=https://cs.github.com/ go
+<pre>{{`$ curl -L -d short=cs -d long=https://cs.github.com/ go
 {"Short":"cs","Long":"https://cs.github.com/","Created":"2022-06-03T22:15:29.993978392Z","LastEdit":"2022-06-03T22:15:29.993978392Z","Owner":"amelie@example.com"}`}}
 </pre>
 


### PR DESCRIPTION
Updates tailscale/golink#9
Fixes tailscale/golink#29

On tailnets with TLS enabled serve HTTP traffic with a separate redirectHandler which sends requests to our HTTPS listener destination.

Add `-L` to documented examples of using `curl` to follow these redirects if present.