### PR TITLE
golink: check for CertDomains before enabling HTTPS

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -189,7 +189,7 @@ out:
 	if err != nil {
 		return err
 	}
-	enableTLS := status.Self.HasCap(tailcfg.CapabilityHTTPS)
+	enableTLS := status.Self.HasCap(tailcfg.CapabilityHTTPS) && len(srv.CertDomains()) > 0
 	fqdn := strings.TrimSuffix(status.Self.DNSName, ".")
 
 	httpHandler := serveHandler()


### PR DESCRIPTION
Fixes https://github.com/tailscale/golink/issues/102

Ensure that we have CertDomains for the HTTPS listener before asking
tsnet to create one.