### PR TITLE
flake.nix: don't wait for network-online.target to start golink

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -147,8 +147,6 @@
                   ${cfg.package}/bin/golink ${builtins.concatStringsSep " " args}
                 '';
               wantedBy = [ "multi-user.target" ];
-              wants = [ "network-online.target" ];
-              after = [ "network-online.target" ];
               serviceConfig = {
                 User = cfg.user;
                 Group = cfg.group;


### PR DESCRIPTION
golink is a tsnet service, and Tailscale's data plane is very good at monitoring for changes to network state and reacting to them. As such, it doesn't need to wait for network-online.target, it can start up concurrently with everything else and shorten the long pole of bootup.

Additionally, network-online.target is an antipattern in systemd that almost never means what people want it to mean. "Online" has no precise definition, and (I posit) almost never matches the ideal version of "online" that people have in their mind. It specifically does _not_ mean that the network functions, or that any particular flavor of connectivity exists. A machine behind a captive portal is "online" for the purposes of bootup, and so is a machine that got a DHCP lease but is having all its packets blackholed. Systemd has a whole page of documentation on "what does online even mean", because this is such a recurring point of confusion: https://systemd.io/NETWORK_ONLINE/

It is almost always wrong to depend on network-online.target, and I wish it was named slow-down-boot-for-no-reason.target, which is how most downstream programs use it.

</rant>, the point is, golink is a well-behaved service that reacts to connectivity changes on the fly (it has to, that's what tailscale does), and so can be started concurrently with networking and other services.