### PR TITLE
Replace deprecated Nix vendorSha256 call with vendorHash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
             version = golinkVersion;
             src = pkgs.nix-gitignore.gitignoreSource [ ] ./.;
 
-            vendorSha256 = "sha256-R/o3csZC/M9nm0k5STL7AhbG5J4LtdxqKaVjM/9ggW8="; # SHA based on vendoring go.mod
+            vendorHash = "sha256-R/o3csZC/M9nm0k5STL7AhbG5J4LtdxqKaVjM/9ggW8="; # SHA based on vendoring go.mod
           };
         };
     }

--- a/update-flake.sh
+++ b/update-flake.sh
@@ -13,4 +13,4 @@ go mod vendor -o "$OUT"
 SHA=$(go run tailscale.com/cmd/nardump --sri "$OUT")
 rm -rf "$OUT"
 
-perl -pi -e "s,vendorSha256 = \".*\"; # SHA based on vendoring go.mod,vendorSha256 = \"$SHA\"; # SHA based on vendoring go.mod," flake.nix
+perl -pi -e "s,vendorHash = \".*\"; # SHA based on vendoring go.mod,vendorHash = \"$SHA\"; # SHA based on vendoring go.mod," flake.nix


### PR DESCRIPTION
When including the flake into my nixos system and doing a rebuild I get the following error:
```
trace: warning: 'vendorSha256' is deprecated. Use 'vendorHash' instead
```

The `vendorHash` function is a drop in replacement, so with this PR the warning will be gone.

(The deprecation of `vendorSha256` can be verified by checking the [nixos 23.11 release notes](https://nixos.org/manual/nixos/stable/release-notes#sec-release-23.11) that say "The argument vendorSha256 of buildGoModule is deprecated. Use vendorHash instead. Refer to [PR #259999](https://github.com/NixOS/nixpkgs/pull/259999) for more details.")