### PR TITLE
go.mod: use latest stable build of tailscale

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
             version = golinkVersion;
             src = pkgs.nix-gitignore.gitignoreSource [ ] ./.;
 
-            vendorHash = "sha256-8s0JadyA8IvfC6zGFJJHrKZHIwBxPLXDfbgy02unqz0="; # SHA based on vendoring go.mod
+            vendorHash = "sha256-PWeQNlIMvhGAFDVwN8fp0B11Loi6zbm1Pds/CKLeuvA="; # SHA based on vendoring go.mod
           };
         };
     }

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	golang.org/x/net v0.20.0
 	modernc.org/sqlite v1.19.4
-	// Always use a pseudo-version for the tailscale.com module, or else
-	// go's version selection causes problems when pulling golink into corp.
-	tailscale.com v1.1.1-0.20240213184936-256ecd0e8f7c
+	tailscale.com v1.60.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -273,5 +273,5 @@ nhooyr.io/websocket v1.8.10 h1:mv4p+MnGrLDcPlBoWsvPP7XCzTYMXP9F9eIGoKbgx7Q=
 nhooyr.io/websocket v1.8.10/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
-tailscale.com v1.1.1-0.20240213184936-256ecd0e8f7c h1:F3cMBBgm3089yk5GWlmwMPGTCOGoAQt84nAiL/A/Ibg=
-tailscale.com v1.1.1-0.20240213184936-256ecd0e8f7c/go.mod h1:qgxvJUlfOWeURBEORdcX4EhoCduFHeBW3FNIZBpmIHY=
+tailscale.com v1.60.1 h1:RNNIuSWE0HeUS7c5i7rAZTCmoDzsAxy5yc5LF4K7pFs=
+tailscale.com v1.60.1/go.mod h1:qgxvJUlfOWeURBEORdcX4EhoCduFHeBW3FNIZBpmIHY=


### PR DESCRIPTION
We have fixed the issue in the corp repo that required us to use pseudo-versions for the tailscale.com module here. So we can now switch to the latest stable version.