### PR TITLE
enable new web ui for managing node

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -161,9 +161,10 @@ func Run() error {
 
 	// create tsNet server and wait for it to be ready & connected.
 	srv := &tsnet.Server{
-		ControlURL: *controlURL,
-		Hostname:   *hostname,
-		Logf:       func(format string, args ...any) {},
+		ControlURL:   *controlURL,
+		Hostname:     *hostname,
+		Logf:         func(format string, args ...any) {},
+		RunWebClient: true,
 	}
 	if *verbose {
 		srv.Logf = log.Printf


### PR DESCRIPTION
we've had support for enabling the web UI in tsnet apps from the beginning, but I don't think we've ever actually used it anywhere. some of the settings exposed through the web ui don't make a ton of sense for tsnet, and might not even work.  But we're working toward being able to enable the web ui on clients by default (with all of the existing restrictions and ACL enforcement in place), and golink seemed like a good playground to try it in a tsnet app.