### PR TITLE
suggest long URL for new go links if peer exists

### DIFF
--- a/tmpl/home.html
+++ b/tmpl/home.html
@@ -1,6 +1,9 @@
 {{ define "main" }}
     <h2 class="text-xl font-bold pb-2">Create a new link</h2>
 
+    {{ with .Long }}
+    <p class="">Did you mean <a class="text-blue-600 hover:underline" href="{{.}}">{{.}}</a> ? Create a go link for it now:</p>
+    {{ end }}
     <form method="POST" action="/" class="flex flex-wrap">
       <div class="flex">
         <label for=short class="flex my-2 px-2 items-center bg-gray-100 border border-r-0 border-gray-300 rounded-l-md text-gray-700">http://go/</label>
@@ -8,7 +11,7 @@
           class="p-2 my-2 rounded-r-md border-gray-300 placeholder:text-gray-400">
         <span class="flex m-2 items-center">&rarr;</span>
       </div>
-      <input name=long required type=text size=40 placeholder="https://destination-url"{{if .Short}} autofocus{{end}} class="p-2 my-2 mr-2 max-w-full rounded-md border-gray-300 placeholder:text-gray-400">
+      <input name=long required type=text size=40 placeholder="https://destination-url"{{if .Short}} value="{{.Long}}" autofocus{{end}} class="p-2 my-2 mr-2 max-w-full rounded-md border-gray-300 placeholder:text-gray-400">
       <button type=submit class="py-2 px-4 my-2 rounded-md bg-blue-500 border-blue-500 text-white hover:bg-blue-600 hover:border-blue-600">Create</button>
     </form>
     <p class="text-sm text-gray-500"><a class="text-blue-600 hover:underline" href="/.help">Help and advanced options</a></p>


### PR DESCRIPTION
If you visit a non-existent go link, we render the home page and pre- populate the "short" input with the name of the link, and autofocus the "long" input so that you can simply paste a long URL and submit.

It is common (at least at Tailscale) to create go links that correspond to the name of a device on the tailnet.  For example, go/who points to http://who/.  With this change, when you visit a non-existent go link, we check to see if a peer exists on the tailnet with that name, and if so we suggest that as the long URL.

Example:
<img width="889" alt="Screenshot 2024-03-15 at 11 48 18 AM" src="https://github.com/tailscale/golink/assets/1112/1340ee6d-1567-4080-afce-133054bba652">

