### PR TITLE
use semantic version tagging for docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,11 @@ jobs:
         uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Build and push Docker image
         id: build-and-push


### PR DESCRIPTION
we've never tagged stable releases, but should really do so.  This change will cause our docker images to be tagged following typical semver fashion... the initial `v1.0.0` release will be tagged `v1`, `v1.0`, `v1.0.0`, and `latest`.

Updates #104

Tested in a fork at [willnorris/tmpgolink](https://github.com/willnorris/tmpgolink).  GitHub Action r[un at the v1.0.0 tag](https://github.com/willnorris/tmpgolink/actions/runs/8529904724), and the [resulting published image](https://github.com/willnorris/tmpgolink/pkgs/container/tmpgolink).