### PR TITLE
add regexp.Match to template funcs

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -629,6 +629,12 @@ var expandFuncMap = texttemplate.FuncMap{
 	"PathEscape":  url.PathEscape,
 	"QueryEscape": url.QueryEscape,
 	"TrimSuffix":  strings.TrimSuffix,
+	"Match":       regexMatch,
+}
+
+func regexMatch(pattern string, s string) bool {
+	b, _ := regexp.MatchString(pattern, s)
+	return b
 }
 
 // expandLink returns the expanded long URL to redirect to, executing any

--- a/golink_test.go
+++ b/golink_test.go
@@ -418,6 +418,18 @@ func TestExpandLink(t *testing.T) {
 			want:      "http://host.com/a",
 		},
 		{
+			name:      "template-with-match-func",
+			long:      `http://host.com/{{if Match "\\d+" .Path}}id/{{.Path}}{{else}}search/{{.Path}}{{end}}`,
+			remainder: "123",
+			want:      "http://host.com/id/123",
+		},
+		{
+			name:      "template-with-match-func2",
+			long:      `http://host.com/{{if Match "\\d+" .Path}}id/{{.Path}}{{else}}search/{{.Path}}{{end}}`,
+			remainder: "query",
+			want:      "http://host.com/search/query",
+		},
+		{
 			name:      "relative-link",
 			long:      `rel`,
 			remainder: "a",

--- a/tmpl/help.html
+++ b/tmpl/help.html
@@ -55,6 +55,8 @@ Templates also have access to the following template functions:
 <ul>
   <li><code>PathEscape</code> is the <a href="https://pkg.go.dev/net/url#PathEscape">url.PathEscape</a> function for escaping values inside a URL path.
   <li><code>QueryEscape</code> is the <a href="https://pkg.go.dev/net/url#QueryEscape">url.QueryEscape</a> function for escaping values inside a URL query.
+  <li><code>TrimSuffix</code> is the <a href="https://pkg.go.dev/strings#TrimSuffix">strings.TrimSuffix</a> function for removing a trailing suffix.
+  <li><code>Match</code> is the <a href="https://pkg.go.dev/regexp#MatchString">regexp.MatchString</a> function for matching a regular expression pattern.
 </ul>
 
 <p>


### PR DESCRIPTION
Add a "Match" template func, which uses regexp.MatchString to match a value against a regular expression pattern.

Internal discussion: https://tailscale.slack.com/archives/C03DHMXREA3/p1715099034944409

cc @garrett-ts 