### PR TITLE
Dockerfile: switch base image to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/wolfi-base as build
-RUN apk update && apk add build-base git openssh go-1.21
+FROM --platform=$BUILDPLATFORM golang:1.23-alpine as build
 
 WORKDIR /work
 
@@ -14,8 +13,7 @@ RUN \
   fi; \
   GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -v ./cmd/golink
 
-
-FROM cgr.dev/chainguard/static:latest
+FROM gcr.io/distroless/static-debian12:nonroot
 
 ENV HOME /home/nonroot
 


### PR DESCRIPTION
Chainguard removed arm/v7 support from their free images: https://www.chainguard.dev/unchained/changes-to-static-git-and-busybox-developer-images

Switch to the official `go` image for builds and distroless for packaging.