### PR TITLE
print restored log statement only with verbose enabled

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -972,7 +972,7 @@ func restoreLastSnapshot() error {
 		}
 		restored++
 	}
-	if restored > 0 {
+	if restored > 0 && *verbose {
 		log.Printf("Restored %v links.", restored)
 	}
 	return bs.Err()


### PR DESCRIPTION
When resolving links from an offline backup, this creates extra noise.

Updates tailscale/corp#22700