### PR TITLE
Dockerfile: install git to populate node version string

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM --platform=$BUILDPLATFORM golang:1.23-alpine as build
 
 WORKDIR /work
 
+# Install git so that go build populates the VCS details in build info, which
+# is then reported to Tailscale in the node version string.
+RUN apk add git
+
 COPY go.mod go.sum ./
 RUN go mod download
 


### PR DESCRIPTION
Without the git CLI, `go build` will not produce the embedded VCS metadata that's used to report the commit hash in node version string. This fixes the `1.72.1-ERR-BuildInfo` version string reported to Tailscale.

Fixes #140