### PR TITLE
golink: strip trailing punctuation when resolving links

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -528,6 +528,15 @@ func serveGo(w http.ResponseWriter, r *http.Request) {
 
 	link, err := db.Load(short)
 	if errors.Is(err, fs.ErrNotExist) {
+		// Trim common punctuation from the end and try again.
+		// This catches auto-linking and copy/paste issues that include punctuation.
+		if s := strings.TrimRight(short, ".,()[]{}"); short != s {
+			short = s
+			link, err = db.Load(short)
+		}
+	}
+
+	if errors.Is(err, fs.ErrNotExist) {
 		w.WriteHeader(http.StatusNotFound)
 		serveHome(w, r, short)
 		return

--- a/golink_test.go
+++ b/golink_test.go
@@ -76,6 +76,31 @@ func TestServeGo(t *testing.T) {
 			wantLink:   "http://who/http://host",
 		},
 		{
+			name:       "simple link, trailing period",
+			link:       "/who.",
+			wantStatus: http.StatusFound,
+			wantLink:   "http://who/",
+		},
+		{
+			name:       "simple link, trailing comma",
+			link:       "/who,",
+			wantStatus: http.StatusFound,
+			wantLink:   "http://who/",
+		},
+		{
+			// This seems like an incredibly unlikely typo, but test it anyway.
+			name:       "simple link, trailing comma and path",
+			link:       "/who,/p",
+			wantStatus: http.StatusFound,
+			wantLink:   "http://who/p",
+		},
+		{
+			name:       "simple link, trailing paren",
+			link:       "/who)",
+			wantStatus: http.StatusFound,
+			wantLink:   "http://who/",
+		},
+		{
 			name:       "user link",
 			link:       "/me",
 			wantStatus: http.StatusFound,


### PR DESCRIPTION
It's not uncommon for auto-linkers or simple copy/paste errors to accidentally include trailing punctuation in a golink. When resolving links, if the initial link was not found, then try again with common punctuation (that is invalid in link names anyway) removed.

Fixes #148

Change-Id: Ia101a4a3005adb9118051b3416f5a64a4a45987d