### PR TITLE
add /.export-stats endpoint to dump stats table

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
               "-X tailscale.com/version.longStamp=${tsVersion}"
               "-X tailscale.com/version.shortStamp=${tsVersion}"
             ];
-          vendorHash = "sha256-k3BxPRTgoJM0oCixDVA2k44ztdAUZO4IcO2/QB19HvU="; # SHA based on vendoring go.mod
+          vendorHash = "sha256-tF3TuIWr5x4inGrykXAjXBQATpDdpTX8HDYmEeukTEc="; # SHA based on vendoring go.mod
         };
       });
 


### PR DESCRIPTION
This is really bare bones, but at least lets us get the stats data out. This also made it clear to me how brittle some of our tests are because of how much global state we have in the top-level golink package. We should probably move all of that into a server type or something similar before too long.

Updates #168

Change-Id: Ia101a4a3005adb9118051b3416f5a64a4a45987d