### PR TITLE
refactor(nix): remove deprecated alias

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
       });
 
       overlays.default = final: prev: {
-        golink = self.packages.${prev.system}.default;
+        golink = self.packages.${prev.stdenv.hostPlatform.system}.default;
       };
 
       nixosModules.default =


### PR DESCRIPTION
`pkgs.system` was deprecated over [4 years ago](https://github.com/NixOS/nixpkgs/commit/4246d6ce21d2d8d33e2d30f42b3d9d446c5dc143), the correct way to do this now is `pkgs.stdenv.hostPlatform.system`.

Fixes build on configs that set `nixpkgs.config.allowAliases = false`.