### PR TITLE
remove XSRF input from templates

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
               "-X tailscale.com/version.longStamp=${tsVersion}"
               "-X tailscale.com/version.shortStamp=${tsVersion}"
             ];
-          vendorHash = "sha256-RqKsIgwkCbIMQdCKtSHqW9eiZuNcZLCYeXFhPbgxjEU="; # SHA based on vendoring go.mod
+          vendorHash = "sha256-PUobfmZyn5YtiFTpxTtjnPhqijR5tsONk4HNlIs1oNk="; # SHA based on vendoring go.mod
         };
       });
 

--- a/tmpl/delete.html
+++ b/tmpl/delete.html
@@ -4,7 +4,6 @@
     <p class="py-4">Deleted this by mistake? You can recreate the same link below.</p>
 
     <form method="POST" action="/">
-      <input type="hidden" name="xsrf" value="{{ .XSRF }}" />
       <div class="flex flex-wrap">
         <div class="flex">
           <label for=short class="flex my-2 px-2 items-center bg-gray-100 border border-r-0 border-gray-300 rounded-l-md text-gray-700">http://{{go}}/</label>

--- a/tmpl/detail.html
+++ b/tmpl/detail.html
@@ -3,7 +3,6 @@
 
     {{ if .Editable }}
     <form method="POST" action="/">
-      <input type="hidden" name="xsrf" value="{{ .XSRF }}" />
       <div class="flex flex-wrap">
         <div class="flex">
           <label for=short class="flex my-2 px-2 items-center bg-gray-100 border border-r-0 border-gray-300 rounded-l-md text-gray-700">http://{{go}}/</label>
@@ -33,7 +32,6 @@
     <h3 class="text-lg font-bold pb-2 pt-4 text-red-500">Danger Zone</h3>
 
     <form method="POST" action="/.delete/{{.Link.Short}}">
-      <input type="hidden" name="xsrf" value="{{ .XSRF }}" />
       <button type=submit class="py-2 px-4 my-2 rounded-md bg-red-500 border-red-500 text-white hover:bg-red-600 hover:border-red-600">Delete Link</button>
     </form>
 

--- a/tmpl/home.html
+++ b/tmpl/home.html
@@ -8,7 +8,6 @@
       <p class="">Did you mean <a class="text-blue-600 hover:underline" href="{{.}}">{{.}}</a> ? Create a {{go}} link for it now:</p>
       {{ end }}
       <form method="POST" action="/" class="flex flex-wrap">
-        <input type="hidden" name="xsrf" value="{{ .XSRF }}" />
         <div class="flex">
           <label for=short class="flex my-2 px-2 items-center bg-gray-100 border border-r-0 border-gray-300 rounded-l-md text-gray-700">http://{{go}}/</label>
           <input id=short name=short required type=text size=15 placeholder="shortname" value="{{.Short}}" pattern="\w[\w\-\.]*" title="Must start with letter or number; may contain letters, numbers, dashes, and periods."


### PR DESCRIPTION
As of #177, we are now using Sec-Fetch-Site instead of xsrf tokens.

Updates #178

Change-Id: Ia101a4a3005adb9118051b3416f5a64a4a45987d