### PR TITLE
Automatically fix flake.nix hashes from dependabot PRs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@aacc1657a206483a9d7037b91370e00407cf3ec5
         with:
           determinate: true
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:
@@ -17,7 +19,30 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: cachix/install-nix-action@v16
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
 
       - name: Run build
         run: nix build
+
+      - name: Fix hash mismatches
+        if: failure() && github.event_name == 'pull_request'
+        id: fix-hashes
+        run: |
+          git stash --include-untracked
+          git fetch --depth=1 origin "$GITHUB_HEAD_REF"
+          git checkout -B "$GITHUB_HEAD_REF" "${{ github.event.pull_request.head.sha }}"
+
+          determinate-nixd fix hashes --auto-apply
+
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add --update --ignore-removal .
+            git commit -m "[dependabot skip] Automatically fix Nix hashes"
+            git push origin "$GITHUB_HEAD_REF"
+          fi
+
+          git checkout -
+          git stash pop || true


### PR DESCRIPTION
This patch uses Determinate Nix 3.3's feature of being able to automatically fix invalid Nix hashes in CI. I recently made this change in our fork of golinks, and thought I'd upstream it. 

It means PRs like https://github.com/tailscale/golink/pull/174 won't need manually pushing fixups too. They'll still need to be closed/reopened for GHA to run tests, though. See this PR on our fork for the same issue: https://github.com/DeterminateSystems/golink/pull/21

More context: https://determinate.systems/posts/changelog-determinate-nix-331/#automatic-hash-mismatches-fixes-in-github-actions
