### PR TITLE
disallow accidental updates to existing links

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -881,6 +881,13 @@ func serveSave(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Prevent accidental overwrites of existing links.
+	// If the link already exists, make sure this request is an intentional update.
+	if link != nil && r.FormValue("update") == "" {
+		http.Error(w, "link already exists", http.StatusForbidden)
+		return
+	}
+
 	if !canEditLink(r.Context(), link, cu) {
 		http.Error(w, fmt.Sprintf("cannot update link owned by %q", link.Owner), http.StatusForbidden)
 		return

--- a/tmpl/detail.html
+++ b/tmpl/detail.html
@@ -26,6 +26,7 @@
         <dd>{{.Link.LastEdit.Format "Jan _2, 2006 3:04pm MST"}}</dd>
       </dl>
 
+      <input type="hidden" name="update" value="1">
       <button type=submit class="py-2 px-4 my-4 rounded-md bg-blue-500 border-blue-500 text-white hover:bg-blue-600 hover:border-blue-600">Update</button>
     </form>
 

--- a/tmpl/help.html
+++ b/tmpl/help.html
@@ -139,5 +139,8 @@ Create a new link by sending a POST request with a <code>short</code> and <code>
 {{`{"Short":"cs","Long":"https://cs.github.com/","Created":"2022-06-03T22:15:29.993978392Z","LastEdit":"2022-06-03T22:15:29.993978392Z","Owner":"amelie@example.com"}`}}
 </pre>
 
+<p>
+To update an existing link, also include `-d update=1`.
+
 </article>
 {{ end }}


### PR DESCRIPTION
Prior to #177, our XSRF tokens were bound to link IDs, with a special `.new` value used for newly created links. So if a user tried to create a link that already existed, the XSRF check would fail. After #177, this now silently allows the user to overwrite the existing link without any indication that this happened.

This change adds a hidden `update` param to the details edit form that must be present when updating an existing link.

Updates #177

Change-Id: Ia101a4a3005adb9118051b3416f5a64a4a45987d