### PR TITLE
golink: revert Sec-Fetch-Site xsrftoken replacement

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
               "-X tailscale.com/version.longStamp=${tsVersion}"
               "-X tailscale.com/version.shortStamp=${tsVersion}"
             ];
-          vendorHash = "sha256-PUobfmZyn5YtiFTpxTtjnPhqijR5tsONk4HNlIs1oNk="; # SHA based on vendoring go.mod
+          vendorHash = "sha256-RqKsIgwkCbIMQdCKtSHqW9eiZuNcZLCYeXFhPbgxjEU="; # SHA based on vendoring go.mod
         };
       });
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.6.0
+	golang.org/x/net v0.38.0
 	modernc.org/sqlite v1.19.4
 	tailscale.com v1.82.5
 )
@@ -76,7 +77,6 @@ require (
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac // indirect
 	golang.org/x/mod v0.23.0 // indirect
-	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/term v0.30.0 // indirect

--- a/tmpl/delete.html
+++ b/tmpl/delete.html
@@ -4,6 +4,7 @@
     <p class="py-4">Deleted this by mistake? You can recreate the same link below.</p>
 
     <form method="POST" action="/">
+      <input type="hidden" name="xsrf" value="{{ .XSRF }}" />
       <div class="flex flex-wrap">
         <div class="flex">
           <label for=short class="flex my-2 px-2 items-center bg-gray-100 border border-r-0 border-gray-300 rounded-l-md text-gray-700">http://{{go}}/</label>

--- a/tmpl/detail.html
+++ b/tmpl/detail.html
@@ -3,6 +3,7 @@
 
     {{ if .Editable }}
     <form method="POST" action="/">
+      <input type="hidden" name="xsrf" value="{{ .XSRF }}" />
       <div class="flex flex-wrap">
         <div class="flex">
           <label for=short class="flex my-2 px-2 items-center bg-gray-100 border border-r-0 border-gray-300 rounded-l-md text-gray-700">http://{{go}}/</label>
@@ -26,13 +27,13 @@
         <dd>{{.Link.LastEdit.Format "Jan _2, 2006 3:04pm MST"}}</dd>
       </dl>
 
-      <input type="hidden" name="update" value="1">
       <button type=submit class="py-2 px-4 my-4 rounded-md bg-blue-500 border-blue-500 text-white hover:bg-blue-600 hover:border-blue-600">Update</button>
     </form>
 
     <h3 class="text-lg font-bold pb-2 pt-4 text-red-500">Danger Zone</h3>
 
     <form method="POST" action="/.delete/{{.Link.Short}}">
+      <input type="hidden" name="xsrf" value="{{ .XSRF }}" />
       <button type=submit class="py-2 px-4 my-2 rounded-md bg-red-500 border-red-500 text-white hover:bg-red-600 hover:border-red-600">Delete Link</button>
     </form>
 

--- a/tmpl/help.html
+++ b/tmpl/help.html
@@ -139,8 +139,5 @@ Create a new link by sending a POST request with a <code>short</code> and <code>
 {{`{"Short":"cs","Long":"https://cs.github.com/","Created":"2022-06-03T22:15:29.993978392Z","LastEdit":"2022-06-03T22:15:29.993978392Z","Owner":"amelie@example.com"}`}}
 </pre>
 
-<p>
-To update an existing link, also include `-d update=1`.
-
 </article>
 {{ end }}

--- a/tmpl/home.html
+++ b/tmpl/home.html
@@ -8,6 +8,7 @@
       <p class="">Did you mean <a class="text-blue-600 hover:underline" href="{{.}}">{{.}}</a> ? Create a {{go}} link for it now:</p>
       {{ end }}
       <form method="POST" action="/" class="flex flex-wrap">
+        <input type="hidden" name="xsrf" value="{{ .XSRF }}" />
         <div class="flex">
           <label for=short class="flex my-2 px-2 items-center bg-gray-100 border border-r-0 border-gray-300 rounded-l-md text-gray-700">http://{{go}}/</label>
           <input id=short name=short required type=text size=15 placeholder="shortname" value="{{.Short}}" pattern="\w[\w\-\.]*" title="Must start with letter or number; may contain letters, numbers, dashes, and periods."


### PR DESCRIPTION
Unfortunately Sec-Fetch-Site headers are not sent over plaintext HTTP
making this unsuitable for non-TLS deployments.

Reverts c89d35095a4884eb84f7652b3376cf789592715f
Reverts 7646755c2e049abfeb65015115964c0bd3b2c887
Reverts a1ce1eb2b611877a42ae612e031c45b660543c51

Updates #160
Updates #156
Updates #130