### PR TITLE
Replace deprecated local client

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -33,7 +33,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/net/xsrftoken"
-	"tailscale.com/client/tailscale"
+	"tailscale.com/client/local"
 	"tailscale.com/hostinfo"
 	"tailscale.com/ipn"
 	"tailscale.com/tailcfg"
@@ -111,7 +111,7 @@ var embeddedFS embed.FS
 // db stores short links.
 var db *SQLiteDB
 
-var localClient *tailscale.LocalClient
+var localClient *local.Client
 
 func Run() error {
 	flag.Parse()


### PR DESCRIPTION
I haven't tested this locally since I'm not sure if testing prod with my personal tailnet will conflict with my existing golink. But it seems like a relatively minor change that should be ok.