### PR TITLE
Add controlUrl option to NixOS module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,15 @@
               description = "Path to SQLite database";
             };
 
+            controlUrl = mkOption {
+              type = types.str;
+              default = "https://controlplane.tailscale.com";
+              description = ''
+                the URL base of the control plane (i.e. coordination server)
+                (default "https://controlplane.tailscale.com")
+              '';
+            };
+
             tailscaleAuthKeyFile = mkOption {
               type = types.nullOr types.path;
               default = null;
@@ -135,7 +144,10 @@
               enable = true;
               script =
                 let
-                  args = [ "--sqlitedb ${cfg.databaseFile}" ] ++ optionals cfg.verbose [ "--verbose" ];
+                  args = [
+                    "--sqlitedb ${cfg.databaseFile}"
+                    "--control-url ${cfg.controlUrl}"
+                  ] ++ optionals cfg.verbose [ "--verbose" ];
                 in
                 ''
                   ${optionalString (cfg.tailscaleAuthKeyFile != null) ''


### PR DESCRIPTION
https://github.com/tailscale/golink/pull/44 added a `--control-url` flag, but the Nix flake's NixOS module does not have a way to configure this.

This PR adds an additional option to the flake NixOS module to configure this flag.