### PR TITLE
"Create" form cannot be used to update links: error message

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -985,6 +985,13 @@ func serveSave(w http.ResponseWriter, r *http.Request) {
 	// For new link creation, the special newShortName value is used.
 	tokenShortName := newShortName
 	if link != nil {
+		// If the link already exists and the request came from the create
+		// form (which uses a newShortName XSRF token), return a clear error
+		// instead of the confusing "invalid XSRF token" message.
+		if xsrftoken.Valid(r.PostFormValue("xsrf"), xsrfKey, cu.login, newShortName) {
+			http.Error(w, "The “Create a new link” form cannot be used to update links", http.StatusConflict)
+			return
+		}
 		tokenShortName = link.Short
 	}
 

--- a/golink_test.go
+++ b/golink_test.go
@@ -159,6 +159,7 @@ func TestServeSave(t *testing.T) {
 		t.Fatal(err)
 	}
 	db.Save(&Link{Short: "link-owned-by-tagged-devices", Long: "/before", Owner: "tagged-devices"})
+	db.Save(&Link{Short: "existing", Long: "http://existing/", Owner: "foo@example.com"})
 
 	fooXSRF := func(short string) string {
 		return xsrftoken.Generate(xsrfKey, "foo@example.com", short)
@@ -234,6 +235,13 @@ func TestServeSave(t *testing.T) {
 			allowUnknownUsers: true,
 			currentUser:       func(*http.Request) (user, error) { return user{}, nil },
 			wantStatus:        http.StatusOK,
+		},
+		{
+			name:       "duplicate link from create form",
+			short:      "existing",
+			xsrf:       fooXSRF(newShortName),
+			long:       "http://existing/other",
+			wantStatus: http.StatusConflict,
 		},
 		{
 			name:       "invalid xsrf",


### PR DESCRIPTION
This is a simple bandaid to produce a better error message in the case of #160, where the "Create a new link" form is used to update an existing link.

Currently, this returns a very confusing error which just says "Invalid XSRF token".

Now, we will show an informative error message.

We should fix this more thoroughly, but the error message will at least make it clear to users that their instance of the golink service is not broken.