### PR TITLE
fix: redirect to detail page when creating a link that already exists

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -667,6 +667,7 @@ type detailData struct {
 	Editable bool
 	Link     *Link
 	XSRF     string
+	Message  string
 }
 
 func serveDetail(w http.ResponseWriter, r *http.Request) {
@@ -711,6 +712,9 @@ func serveDetail(w http.ResponseWriter, r *http.Request) {
 		Link:     link,
 		Editable: canEdit,
 		XSRF:     xsrftoken.Generate(xsrfKey, cu.login, link.Short),
+	}
+	if r.URL.Query().Get("exists") == "1" {
+		data.Message = "A link with this short name already exists. You can edit it below."
 	}
 	if canEdit && !ownerExists {
 		data.Link.Owner = cu.login
@@ -983,13 +987,24 @@ func serveSave(w http.ResponseWriter, r *http.Request) {
 
 	// short name to use for XSRF token.
 	// For new link creation, the special newShortName value is used.
+	// For existing links, the link's short name is used. This intentionally
+	// prevents the home page "create" form from overwriting an existing link;
+	// to edit an existing link the user must use the detail page edit form
+	// which generates a token scoped to that link's short name.
 	tokenShortName := newShortName
 	if link != nil {
 		tokenShortName = link.Short
 	}
 
 	if !isRequestAuthorized(r, cu, tokenShortName) {
-		http.Error(w, "invalid XSRF token", http.StatusBadRequest)
+		if link != nil && isRequestAuthorized(r, cu, newShortName) {
+			// The user submitted from the home page create form but the link
+			// already exists. Redirect to the detail page so they can edit it
+			// intentionally rather than accidentally overwriting it.
+			http.Redirect(w, r, "/.detail/"+url.PathEscape(short)+"?exists=1", http.StatusSeeOther)
+		} else {
+			http.Error(w, "invalid XSRF token", http.StatusBadRequest)
+		}
 		return
 	}
 

--- a/golink_test.go
+++ b/golink_test.go
@@ -175,6 +175,7 @@ func TestServeSave(t *testing.T) {
 		allowUnknownUsers bool
 		currentUser       func(*http.Request) (user, error)
 		wantStatus        int
+		wantLocation      string
 	}{
 		{
 			name:       "missing short",
@@ -236,6 +237,15 @@ func TestServeSave(t *testing.T) {
 			wantStatus:        http.StatusOK,
 		},
 		{
+			name:         "redirect to detail page when creating link that already exists",
+			short:        "who",
+			xsrf:         barXSRF(newShortName),
+			long:         "http://who/updated",
+			currentUser:  func(*http.Request) (user, error) { return user{login: "bar@example.com", isAdmin: true}, nil },
+			wantStatus:   http.StatusSeeOther,
+			wantLocation: "/.detail/who?exists=1",
+		},
+		{
 			name:       "invalid xsrf",
 			short:      "goat",
 			xsrf:       fooXSRF("sheep"),
@@ -269,6 +279,11 @@ func TestServeSave(t *testing.T) {
 
 			if w.Code != tt.wantStatus {
 				t.Errorf("serveSave(%q, %q) = %d; want %d", tt.short, tt.long, w.Code, tt.wantStatus)
+			}
+			if tt.wantLocation != "" {
+				if got := w.Header().Get("Location"); got != tt.wantLocation {
+					t.Errorf("serveSave(%q, %q) Location = %q; want %q", tt.short, tt.long, got, tt.wantLocation)
+				}
 			}
 		})
 	}

--- a/tmpl/detail.html
+++ b/tmpl/detail.html
@@ -1,4 +1,7 @@
 {{ define "main" }}
+   {{ if .Message }}
+   <div class="py-2 px-4 mb-6 rounded-md border text-sm border-orange-50 bg-orange-0 text-gray-700">{{ .Message }}</div>
+   {{ end }}
    <h2 class="text-xl font-bold pb-2">Link Details</h2>
 
     {{ if .Editable }}


### PR DESCRIPTION
When attempting to create a link that already exists, redirect to the details page of the existing link to allow for updating.

Fixes #160