### PR TITLE
flake.nix: Fix ambiguous backslash-escape in the version number regex

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
             let
               tsVersion =
                 with builtins;
-                head (match ".*tailscale.com v([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z]?).*" (readFile ./go.mod));
+                head (match ".*tailscale.com v([0-9]+\\.[0-9]+\\.[0-9]+-?[a-zA-Z]?).*" (readFile ./go.mod));
             in
             [
               "-w"


### PR DESCRIPTION
The latest version of lix (v2.95.1) has deprecated \. as a string escape as it is ill-defined, issuing this warning now:

```
warning: \. is an ill-defined escape. You can drop the \ and simply write . instead. Use --extra-deprecated-features broken-string-escape to silence this warning.
```

But unfortunately, using "." doesn't carry the intended meaning. What we need to do here is to use "\\." to match a regex-escaped period.

This PR fixes the ambiguity, ensuring the regex matches the intended target string unambiguously.