### PR TITLE
fix: differentiate exists message for owners

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -664,10 +664,10 @@ func acceptHTML(r *http.Request) bool {
 // detailData is the data used by the detailTmpl template.
 type detailData struct {
 	// Editable indicates whether the current user can edit the link.
-	Editable bool
-	Link     *Link
-	XSRF     string
-	Message  string
+	Editable      bool
+	Link          *Link
+	XSRF          string
+	AlreadyExists bool
 }
 
 func serveDetail(w http.ResponseWriter, r *http.Request) {
@@ -714,7 +714,7 @@ func serveDetail(w http.ResponseWriter, r *http.Request) {
 		XSRF:     xsrftoken.Generate(xsrfKey, cu.login, link.Short),
 	}
 	if r.URL.Query().Get("exists") == "1" {
-		data.Message = "A link with this short name already exists. You can edit it below."
+		data.AlreadyExists = true
 	}
 	if canEdit && !ownerExists {
 		data.Link.Owner = cu.login

--- a/tmpl/detail.html
+++ b/tmpl/detail.html
@@ -1,6 +1,8 @@
 {{ define "main" }}
-   {{ if .Message }}
-   <div class="py-2 px-4 mb-6 rounded-md border text-sm border-orange-50 bg-orange-0 text-gray-700">{{ .Message }}</div>
+   {{ if .AlreadyExists }}
+   <div class="py-2 px-4 mb-6 rounded-md border text-sm border-orange-50 bg-orange-0 text-gray-700">
+     {{ if .Editable }}A link with this short name already exists. You can edit it below.{{ else }}A link with this short name already exists.{{ end }}
+   </div>
    {{ end }}
    <h2 class="text-xl font-bold pb-2">Link Details</h2>
 


### PR DESCRIPTION
Update the golink exists error message for owners
vs non owners

Updates #160