### PR TITLE
Add time-based filtering to Popular Links

### DIFF
--- a/db.go
+++ b/db.go
@@ -194,31 +194,29 @@ func (s *SQLiteDB) LoadStats() (ClickStats, error) {
 
 // LoadStatsSince returns click stats for links since the given time.
 func (s *SQLiteDB) LoadStatsSince(since time.Time) (ClickStats, error) {
-	allLinks, err := s.LoadAll()
-	if err != nil {
-		return nil, err
-	}
-	linkmap := make(map[string]string, len(allLinks)) // map ID => Short
-	for _, link := range allLinks {
-		linkmap[linkID(link.Short)] = link.Short
-	}
-
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	rows, err := s.db.Query("SELECT ID, sum(Clicks) FROM Stats WHERE Created >= ? GROUP BY ID", since.Unix())
+	rows, err := s.db.Query(`
+		SELECT Links.Short, sum(Stats.Clicks)
+		FROM Stats
+		JOIN Links ON Stats.ID = Links.ID
+		WHERE Stats.Created >= ?
+		GROUP BY Links.ID, Links.Short
+	`, since.Unix())
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
+
 	stats := make(map[string]int)
 	for rows.Next() {
-		var id string
+		var short string
 		var clicks int
-		err := rows.Scan(&id, &clicks)
+		err := rows.Scan(&short, &clicks)
 		if err != nil {
 			return nil, err
 		}
-		short := linkmap[id]
 		stats[short] = clicks
 	}
 	return stats, rows.Err()

--- a/db.go
+++ b/db.go
@@ -192,6 +192,38 @@ func (s *SQLiteDB) LoadStats() (ClickStats, error) {
 	return stats, rows.Err()
 }
 
+// LoadStatsSince returns click stats for links since the given time.
+func (s *SQLiteDB) LoadStatsSince(since time.Time) (ClickStats, error) {
+	allLinks, err := s.LoadAll()
+	if err != nil {
+		return nil, err
+	}
+	linkmap := make(map[string]string, len(allLinks)) // map ID => Short
+	for _, link := range allLinks {
+		linkmap[linkID(link.Short)] = link.Short
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	rows, err := s.db.Query("SELECT ID, sum(Clicks) FROM Stats WHERE Created >= ? GROUP BY ID", since.Unix())
+	if err != nil {
+		return nil, err
+	}
+	stats := make(map[string]int)
+	for rows.Next() {
+		var id string
+		var clicks int
+		err := rows.Scan(&id, &clicks)
+		if err != nil {
+			return nil, err
+		}
+		short := linkmap[id]
+		stats[short] = clicks
+	}
+	return stats, rows.Err()
+}
+
 // SaveStats records click stats for links.  The provided map includes
 // incremental clicks that have occurred since the last time SaveStats
 // was called.

--- a/db.go
+++ b/db.go
@@ -84,6 +84,8 @@ func (s *SQLiteDB) LoadAll() ([]*Link, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 		link := new(Link)
 		var created, lastEdit int64
@@ -178,6 +180,8 @@ func (s *SQLiteDB) LoadStats() (ClickStats, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
+
 	stats := make(map[string]int)
 	for rows.Next() {
 		var id string
@@ -266,6 +270,8 @@ func (s *SQLiteDB) GetLinksByOwner(owner string) ([]*Link, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 		link := new(Link)
 		var created, lastEdit int64

--- a/db_test.go
+++ b/db_test.go
@@ -6,9 +6,11 @@ package golink
 import (
 	"path"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"tailscale.com/tstest"
 )
 
 // Test saving, loading, and deleting links for SQLiteDB.
@@ -123,6 +125,59 @@ func Test_SQLiteDB_SaveLoadDeleteStats(t *testing.T) {
 	want = ClickStats{}
 	if !cmp.Equal(got, want) {
 		t.Errorf("db.LoadStats got %v, want %v", got, want)
+	}
+}
+
+// Test LoadStatsSince returns only stats since a given time.
+func Test_SQLiteDB_LoadStatsSince(t *testing.T) {
+	clock := tstest.NewClock(tstest.ClockOpts{
+		Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+
+	db, err := NewSQLiteDB(path.Join(t.TempDir(), "links.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.clock = clock
+
+	// preload links
+	for _, link := range []*Link{{Short: "a"}, {Short: "b"}} {
+		if err := db.Save(link); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// save stats at initial time (old stats)
+	if err := db.SaveStats(ClickStats{"a": 5, "b": 3}); err != nil {
+		t.Fatal(err)
+	}
+
+	// advance 20 days and save more stats (recent stats)
+	clock.Advance(20 * 24 * time.Hour)
+	if err := db.SaveStats(ClickStats{"a": 2, "b": 7}); err != nil {
+		t.Fatal(err)
+	}
+
+	// LoadStatsSince 10 days ago should only return the recent stats
+	since := clock.Now().Add(-10 * 24 * time.Hour)
+	got, err := db.LoadStatsSince(since)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := ClickStats{"a": 2, "b": 7}
+	if !cmp.Equal(got, want) {
+		t.Errorf("LoadStatsSince got %v, want %v", got, want)
+	}
+
+	// LoadStatsSince 30 days ago should return all stats
+	since = clock.Now().Add(-30 * 24 * time.Hour)
+	got, err = db.LoadStatsSince(since)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = ClickStats{"a": 7, "b": 10}
+	if !cmp.Equal(got, want) {
+		t.Errorf("LoadStatsSince got %v, want %v", got, want)
 	}
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -154,7 +154,7 @@ func Test_SQLiteDB_LoadStatsSince(t *testing.T) {
 
 	// advance 20 days and save more stats (recent stats)
 	clock.Advance(20 * 24 * time.Hour)
-	if err := db.SaveStats(ClickStats{"a": 2, "b": 7}); err != nil {
+	if err := db.SaveStats(ClickStats{"a": 2, "b": 7, "missing": 11}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/golink.go
+++ b/golink.go
@@ -344,6 +344,7 @@ type homeData struct {
 	XSRF     string
 	ReadOnly bool
 	User     string
+	Period   string
 }
 
 // deleteData is the data used by deleteTmpl.
@@ -535,14 +536,43 @@ func serveHandler() http.Handler {
 func serveHome(w http.ResponseWriter, r *http.Request, short string) {
 	var clicks []visitData
 
-	stats.mu.Lock()
-	for short, numClicks := range stats.clicks {
-		clicks = append(clicks, visitData{
-			Short:     short,
-			NumClicks: numClicks,
-		})
+	period := r.URL.Query().Get("period")
+	switch period {
+	case "7d", "30d":
+		var days int
+		if period == "7d" {
+			days = 7
+		} else {
+			days = 30
+		}
+		since := db.Now().AddDate(0, 0, -days)
+
+		if err := flushStats(); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		clickStats, err := db.LoadStatsSince(since)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		for s, numClicks := range clickStats {
+			clicks = append(clicks, visitData{
+				Short:     s,
+				NumClicks: numClicks,
+			})
+		}
+	default:
+		period = ""
+		stats.mu.Lock()
+		for short, numClicks := range stats.clicks {
+			clicks = append(clicks, visitData{
+				Short:     short,
+				NumClicks: numClicks,
+			})
+		}
+		stats.mu.Unlock()
 	}
-	stats.mu.Unlock()
 
 	sort.Slice(clicks, func(i, j int) bool {
 		if clicks[i].NumClicks != clicks[j].NumClicks {
@@ -580,6 +610,7 @@ func serveHome(w http.ResponseWriter, r *http.Request, short string) {
 		XSRF:     xsrftoken.Generate(xsrfKey, cu.login, newShortName),
 		ReadOnly: *readonly,
 		User:     cu.login,
+		Period:   period,
 	})
 }
 

--- a/golink.go
+++ b/golink.go
@@ -519,10 +519,6 @@ func serveHome(w http.ResponseWriter, r *http.Request, short string) {
 		}
 		since := db.Now().AddDate(0, 0, -days)
 
-		if err := flushStats(); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
 		clickStats, err := db.LoadStatsSince(since)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/golink.go
+++ b/golink.go
@@ -316,6 +316,7 @@ type homeData struct {
 	XSRF     string
 	ReadOnly bool
 	User     string
+	Period   string
 }
 
 // deleteData is the data used by deleteTmpl.
@@ -507,14 +508,43 @@ func serveHandler() http.Handler {
 func serveHome(w http.ResponseWriter, r *http.Request, short string) {
 	var clicks []visitData
 
-	stats.mu.Lock()
-	for short, numClicks := range stats.clicks {
-		clicks = append(clicks, visitData{
-			Short:     short,
-			NumClicks: numClicks,
-		})
+	period := r.URL.Query().Get("period")
+	switch period {
+	case "7d", "30d":
+		var days int
+		if period == "7d" {
+			days = 7
+		} else {
+			days = 30
+		}
+		since := db.Now().AddDate(0, 0, -days)
+
+		if err := flushStats(); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		clickStats, err := db.LoadStatsSince(since)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		for s, numClicks := range clickStats {
+			clicks = append(clicks, visitData{
+				Short:     s,
+				NumClicks: numClicks,
+			})
+		}
+	default:
+		period = ""
+		stats.mu.Lock()
+		for short, numClicks := range stats.clicks {
+			clicks = append(clicks, visitData{
+				Short:     short,
+				NumClicks: numClicks,
+			})
+		}
+		stats.mu.Unlock()
 	}
-	stats.mu.Unlock()
 
 	sort.Slice(clicks, func(i, j int) bool {
 		if clicks[i].NumClicks != clicks[j].NumClicks {
@@ -552,6 +582,7 @@ func serveHome(w http.ResponseWriter, r *http.Request, short string) {
 		XSRF:     xsrftoken.Generate(xsrfKey, cu.login, newShortName),
 		ReadOnly: *readonly,
 		User:     cu.login,
+		Period:   period,
 	})
 }
 

--- a/golink.go
+++ b/golink.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	texttemplate "text/template"
@@ -537,15 +538,8 @@ func serveHome(w http.ResponseWriter, r *http.Request, short string) {
 	var clicks []visitData
 
 	period := r.URL.Query().Get("period")
-	switch period {
-	case "7d", "30d":
-		var days int
-		if period == "7d" {
-			days = 7
-		} else {
-			days = 30
-		}
-		since := db.Now().AddDate(0, 0, -days)
+	if periodDuration, ok := parseStatsPeriod(period); ok {
+		since := db.Now().Add(-periodDuration)
 
 		clickStats, err := db.LoadStatsSince(since)
 		if err != nil {
@@ -558,7 +552,7 @@ func serveHome(w http.ResponseWriter, r *http.Request, short string) {
 				NumClicks: numClicks,
 			})
 		}
-	default:
+	} else {
 		period = ""
 		stats.mu.Lock()
 		for short, numClicks := range stats.clicks {
@@ -608,6 +602,22 @@ func serveHome(w http.ResponseWriter, r *http.Request, short string) {
 		User:     cu.login,
 		Period:   period,
 	})
+}
+
+func parseStatsPeriod(period string) (time.Duration, bool) {
+	if period == "" {
+		return 0, false
+	}
+	if d, err := time.ParseDuration(period); err == nil && d > 0 {
+		return d, true
+	}
+	if days, ok := strings.CutSuffix(period, "d"); ok {
+		n, err := strconv.Atoi(days)
+		if err == nil && n > 0 {
+			return time.Duration(n) * 24 * time.Hour, true
+		}
+	}
+	return 0, false
 }
 
 func serveAll(w http.ResponseWriter, _ *http.Request) {

--- a/golink.go
+++ b/golink.go
@@ -46,6 +46,7 @@ import (
 
 const (
 	defaultHostname = "go"
+	maxStatsPeriod  = 365 * 24 * time.Hour
 
 	// Used as a placeholder short name for generating the XSRF defense token,
 	// when creating new links.
@@ -608,12 +609,12 @@ func parseStatsPeriod(period string) (time.Duration, bool) {
 	if period == "" {
 		return 0, false
 	}
-	if d, err := time.ParseDuration(period); err == nil && d > 0 {
+	if d, err := time.ParseDuration(period); err == nil && d > 0 && d <= maxStatsPeriod {
 		return d, true
 	}
 	if days, ok := strings.CutSuffix(period, "d"); ok {
 		n, err := strconv.Atoi(days)
-		if err == nil && n > 0 {
+		if err == nil && n > 0 && n <= int(maxStatsPeriod/(24*time.Hour)) {
 			return time.Duration(n) * 24 * time.Hour, true
 		}
 	}

--- a/golink.go
+++ b/golink.go
@@ -547,10 +547,6 @@ func serveHome(w http.ResponseWriter, r *http.Request, short string) {
 		}
 		since := db.Now().AddDate(0, 0, -days)
 
-		if err := flushStats(); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
 		clickStats, err := db.LoadStatsSince(since)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/golink_test.go
+++ b/golink_test.go
@@ -849,6 +849,92 @@ func TestServeSearch(t *testing.T) {
 	}
 }
 
+func TestServeHomePeriodFilter(t *testing.T) {
+	clock := tstest.NewClock(tstest.ClockOpts{
+		Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+
+	var err error
+	db, err = NewSQLiteDB(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.clock = clock
+
+	db.Save(&Link{Short: "old-link", Long: "http://old/"})
+	db.Save(&Link{Short: "new-link", Long: "http://new/"})
+
+	// save old stats (40 days ago)
+	if err := db.SaveStats(ClickStats{"old-link": 10}); err != nil {
+		t.Fatal(err)
+	}
+
+	// advance 40 days and save recent stats
+	clock.Advance(40 * 24 * time.Hour)
+	if err := db.SaveStats(ClickStats{"new-link": 5}); err != nil {
+		t.Fatal(err)
+	}
+
+	initStats()
+
+	tests := []struct {
+		name            string
+		period          string
+		wantStatus      int
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name:         "all time shows all links",
+			period:       "",
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"old-link", "new-link"},
+		},
+		{
+			name:            "7d shows only recent link",
+			period:          "7d",
+			wantStatus:      http.StatusOK,
+			wantContains:    []string{"new-link"},
+			wantNotContains: []string{"old-link"},
+		},
+		{
+			name:            "30d shows only recent link",
+			period:          "30d",
+			wantStatus:      http.StatusOK,
+			wantContains:    []string{"new-link"},
+			wantNotContains: []string{"old-link"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := "/"
+			if tt.period != "" {
+				url = "/?period=" + tt.period
+			}
+			r := httptest.NewRequest("GET", url, nil)
+			w := httptest.NewRecorder()
+			serveHandler().ServeHTTP(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("serveHome(?period=%s) = %d; want %d", tt.period, w.Code, tt.wantStatus)
+			}
+
+			body := w.Body.String()
+			for _, s := range tt.wantContains {
+				if !strings.Contains(body, s) {
+					t.Errorf("serveHome(?period=%s) body missing %q", tt.period, s)
+				}
+			}
+			for _, s := range tt.wantNotContains {
+				if strings.Contains(body, s) {
+					t.Errorf("serveHome(?period=%s) body unexpectedly contains %q", tt.period, s)
+				}
+			}
+		})
+	}
+}
+
 func TestParseAdvertiseTags(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/golink_test.go
+++ b/golink_test.go
@@ -861,8 +861,12 @@ func TestServeHomePeriodFilter(t *testing.T) {
 	}
 	db.clock = clock
 
-	db.Save(&Link{Short: "old-link", Long: "http://old/"})
-	db.Save(&Link{Short: "new-link", Long: "http://new/"})
+	if err := db.Save(&Link{Short: "old-link", Long: "http://old/"}); err != nil {
+		t.Fatalf("saving old-link: %v", err)
+	}
+	if err := db.Save(&Link{Short: "new-link", Long: "http://new/"}); err != nil {
+		t.Fatalf("saving new-link: %v", err)
+	}
 
 	// save old stats (40 days ago)
 	if err := db.SaveStats(ClickStats{"old-link": 10}); err != nil {
@@ -875,7 +879,9 @@ func TestServeHomePeriodFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	initStats()
+	if err := initStats(); err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []struct {
 		name            string
@@ -898,11 +904,24 @@ func TestServeHomePeriodFilter(t *testing.T) {
 			wantNotContains: []string{"old-link"},
 		},
 		{
+			name:            "duration shows only recent link",
+			period:          "168h",
+			wantStatus:      http.StatusOK,
+			wantContains:    []string{"new-link"},
+			wantNotContains: []string{"old-link"},
+		},
+		{
 			name:            "30d shows only recent link",
 			period:          "30d",
 			wantStatus:      http.StatusOK,
 			wantContains:    []string{"new-link"},
 			wantNotContains: []string{"old-link"},
+		},
+		{
+			name:         "invalid period falls back to all time",
+			period:       "nope",
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"old-link", "new-link"},
 		},
 	}
 
@@ -930,6 +949,49 @@ func TestServeHomePeriodFilter(t *testing.T) {
 				if strings.Contains(body, s) {
 					t.Errorf("serveHome(?period=%s) body unexpectedly contains %q", tt.period, s)
 				}
+			}
+		})
+	}
+}
+
+func TestParseStatsPeriod(t *testing.T) {
+	tests := []struct {
+		name   string
+		period string
+		want   time.Duration
+		wantOK bool
+	}{
+		{
+			name:   "empty",
+			period: "",
+		},
+		{
+			name:   "days",
+			period: "7d",
+			want:   7 * 24 * time.Hour,
+			wantOK: true,
+		},
+		{
+			name:   "duration",
+			period: "168h",
+			want:   168 * time.Hour,
+			wantOK: true,
+		},
+		{
+			name:   "negative",
+			period: "-7d",
+		},
+		{
+			name:   "invalid",
+			period: "nope",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseStatsPeriod(tt.period)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("parseStatsPeriod(%q) = %v, %v; want %v, %v", tt.period, got, ok, tt.want, tt.wantOK)
 			}
 		})
 	}

--- a/golink_test.go
+++ b/golink_test.go
@@ -978,8 +978,26 @@ func TestParseStatsPeriod(t *testing.T) {
 			wantOK: true,
 		},
 		{
+			name:   "max duration",
+			period: "8760h",
+			want:   maxStatsPeriod,
+			wantOK: true,
+		},
+		{
+			name:   "too long duration",
+			period: "8761h",
+		},
+		{
+			name:   "too many days",
+			period: "366d",
+		},
+		{
 			name:   "negative",
 			period: "-7d",
+		},
+		{
+			name:   "overflowing days",
+			period: "100000000000000000000d",
 		},
 		{
 			name:   "invalid",

--- a/golink_test.go
+++ b/golink_test.go
@@ -845,6 +845,92 @@ func TestServeSearch(t *testing.T) {
 	}
 }
 
+func TestServeHomePeriodFilter(t *testing.T) {
+	clock := tstest.NewClock(tstest.ClockOpts{
+		Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+
+	var err error
+	db, err = NewSQLiteDB(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.clock = clock
+
+	db.Save(&Link{Short: "old-link", Long: "http://old/"})
+	db.Save(&Link{Short: "new-link", Long: "http://new/"})
+
+	// save old stats (40 days ago)
+	if err := db.SaveStats(ClickStats{"old-link": 10}); err != nil {
+		t.Fatal(err)
+	}
+
+	// advance 40 days and save recent stats
+	clock.Advance(40 * 24 * time.Hour)
+	if err := db.SaveStats(ClickStats{"new-link": 5}); err != nil {
+		t.Fatal(err)
+	}
+
+	initStats()
+
+	tests := []struct {
+		name            string
+		period          string
+		wantStatus      int
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name:         "all time shows all links",
+			period:       "",
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"old-link", "new-link"},
+		},
+		{
+			name:            "7d shows only recent link",
+			period:          "7d",
+			wantStatus:      http.StatusOK,
+			wantContains:    []string{"new-link"},
+			wantNotContains: []string{"old-link"},
+		},
+		{
+			name:            "30d shows only recent link",
+			period:          "30d",
+			wantStatus:      http.StatusOK,
+			wantContains:    []string{"new-link"},
+			wantNotContains: []string{"old-link"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := "/"
+			if tt.period != "" {
+				url = "/?period=" + tt.period
+			}
+			r := httptest.NewRequest("GET", url, nil)
+			w := httptest.NewRecorder()
+			serveHandler().ServeHTTP(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("serveHome(?period=%s) = %d; want %d", tt.period, w.Code, tt.wantStatus)
+			}
+
+			body := w.Body.String()
+			for _, s := range tt.wantContains {
+				if !strings.Contains(body, s) {
+					t.Errorf("serveHome(?period=%s) body missing %q", tt.period, s)
+				}
+			}
+			for _, s := range tt.wantNotContains {
+				if strings.Contains(body, s) {
+					t.Errorf("serveHome(?period=%s) body unexpectedly contains %q", tt.period, s)
+				}
+			}
+		})
+	}
+}
+
 func TestParseAdvertiseTags(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/schema.sql
+++ b/schema.sql
@@ -12,3 +12,5 @@ CREATE TABLE IF NOT EXISTS Stats (
 	Created  INTEGER NOT NULL DEFAULT (strftime('%s', 'now')), -- unix seconds
 	Clicks   INTEGER
 );
+
+CREATE INDEX IF NOT EXISTS idx_stats_created ON Stats (Created);

--- a/tmpl/home.html
+++ b/tmpl/home.html
@@ -22,6 +22,11 @@
     {{ end }}
 
     <h2 class="text-xl font-bold pt-6 pb-2">Popular Links</h2>
+    <div class="pb-2">
+      <a href="/?period=7d" class="inline-block text-sm px-2 py-2 mr-2 rounded-md {{if eq .Period "7d"}}bg-blue-500 text-white{{else}}text-blue-600 hover:underline{{end}}">7 days</a>
+      <a href="/?period=30d" class="inline-block text-sm px-2 py-2 mr-2 rounded-md {{if eq .Period "30d"}}bg-blue-500 text-white{{else}}text-blue-600 hover:underline{{end}}">30 days</a>
+      <a href="/" class="inline-block text-sm px-2 py-2 mr-2 rounded-md {{if eq .Period ""}}bg-blue-500 text-white{{else}}text-blue-600 hover:underline{{end}}">All time</a>
+    </div>
     <table class="table-auto ">
       <thead class="border-b border-gray-200 uppercase text-xs text-gray-500 text-left">
         <tr>


### PR DESCRIPTION
## Summary
- Adds 7-day, 30-day, and all-time filter buttons to the Popular Links section on the home page
- Adds `LoadStatsSince` DB method backed by a single `Stats`/`Links` join query and an index on `Stats(Created)` for efficient time-filtered aggregation
- Parses `period` as a bounded duration so pre-populated filters and arbitrary positive periods up to 365 days are supported without allowing unbounded full-history DB scans
- Time-filtered queries read directly from the DB without calling `flushStats`, avoiding serialization of home page requests under load (stats are at most ~1 minute stale via the periodic flush loop)
- Closes DB result sets in the new query path and adjacent DB readers

## Test plan
- [x] New unit test for `LoadStatsSince` in `db_test.go`, including stale stats for missing links
- [x] New integration test `TestServeHomePeriodFilter` in `golink_test.go` covering all-time, 7d, 30d, arbitrary duration, and invalid period fallback
- [x] New unit test coverage for `parseStatsPeriod`, including bounds and overflow cases
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] Local UI screenshots captured for all-time and 7-day filter states