### PR TITLE
feat: show click counts on the /.all and search listings

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -336,6 +336,30 @@ type visitData struct {
 	NumClicks int
 }
 
+// searchResult is a link paired with its current click count, used to render
+// the listing template (searchTmpl) served by /.all and /.search.
+type searchResult struct {
+	*Link
+	NumClicks int
+}
+
+// searchResults annotates links with their current click counts (read from the
+// live in-memory counter, the same source the home page uses), preserving the
+// historical alphabetical ordering by short name.
+func searchResults(links []*Link) []searchResult {
+	stats.mu.Lock()
+	results := make([]searchResult, len(links))
+	for i, link := range links {
+		results[i] = searchResult{Link: link, NumClicks: stats.clicks[link.Short]}
+	}
+	stats.mu.Unlock()
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Short < results[j].Short
+	})
+	return results
+}
+
 // homeData is the data used by homeTmpl.
 type homeData struct {
 	Short    string
@@ -594,11 +618,8 @@ func serveAll(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	sort.Slice(links, func(i, j int) bool {
-		return links[i].Short < links[j].Short
-	})
 
-	searchTmpl.Execute(w, links)
+	searchTmpl.Execute(w, searchResults(links))
 }
 
 func serveHelp(w http.ResponseWriter, _ *http.Request) {
@@ -766,10 +787,7 @@ func serveSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sort.Slice(links, func(i, j int) bool {
-		return links[i].Short < links[j].Short
-	})
-	searchTmpl.Execute(w, links)
+	searchTmpl.Execute(w, searchResults(links))
 }
 
 type expandEnv struct {

--- a/golink_test.go
+++ b/golink_test.go
@@ -849,6 +849,44 @@ func TestServeSearch(t *testing.T) {
 	}
 }
 
+func TestSearchResults(t *testing.T) {
+	stats.mu.Lock()
+	stats.clicks = ClickStats{"alpha": 3, "beta": 10}
+	stats.mu.Unlock()
+	t.Cleanup(func() {
+		stats.mu.Lock()
+		stats.clicks = nil
+		stats.mu.Unlock()
+	})
+
+	links := []*Link{
+		{Short: "alpha"},
+		{Short: "beta"},
+		{Short: "gamma"}, // no recorded clicks; should annotate to 0
+	}
+
+	// Expect the historical alphabetical ordering by short name, with each
+	// link annotated with its current click count.
+	want := []struct {
+		Short     string
+		NumClicks int
+	}{
+		{Short: "alpha", NumClicks: 3},
+		{Short: "beta", NumClicks: 10},
+		{Short: "gamma", NumClicks: 0},
+	}
+
+	got := searchResults(links)
+	if len(got) != len(want) {
+		t.Fatalf("searchResults returned %d results; want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i].Short != w.Short || got[i].NumClicks != w.NumClicks {
+			t.Errorf("result[%d] = {%q, %d}; want {%q, %d}", i, got[i].Short, got[i].NumClicks, w.Short, w.NumClicks)
+		}
+	}
+}
+
 func TestParseAdvertiseTags(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/tmpl/search.html
+++ b/tmpl/search.html
@@ -6,6 +6,7 @@
           <th class="flex-1 p-2">Link</th>
           <th class="hidden md:block w-60 truncate p-2">Owner</th>
           <th class="hidden md:block w-32 p-2">Last Edited</th>
+          <th class="hidden md:block w-20 p-2">Clicks</th>
         </tr>
       </thead>
       <tbody>
@@ -21,9 +22,11 @@
             <p class="text-sm leading-normal text-gray-500 group-hover:text-gray-700 max-w-[75vw] md:max-w-[40vw] truncate">{{ .Long }}</p>
             <p class="md:hidden text-sm leading-normal text-gray-700"><span class="text-gray-500 inline-block w-20">Owner</span> {{ .Owner }}</p>
             <p class="md:hidden text-sm leading-normal text-gray-700"><span class="text-gray-500 inline-block w-20">Last Edited</span> {{ .LastEdit.Format "Jan 2, 2006" }}</p>
+            <p class="md:hidden text-sm leading-normal text-gray-700"><span class="text-gray-500 inline-block w-20">Clicks</span> {{ .NumClicks }}</p>
           </td>
           <td class="hidden md:block w-60 truncate p-2">{{ .Owner }}</td>
           <td class="hidden md:block w-32 p-2">{{ .LastEdit.Format "Jan 2, 2006" }}</td>
+          <td class="hidden md:block w-20 p-2">{{ .NumClicks }}</td>
         </tr>
       {{ end }}
       </tbody>


### PR DESCRIPTION
The home page already shows click counts in the Popular Links table, but that table is capped at the top 200 links and there's no way to see counts when browsing the full list. This adds a Clicks column to the `/.all` page so you can see how often each link actually gets used.

The owner search page (`/.search?q=owner:...`) renders the same template, so it gets the column too. Counts come from the same in-memory counter the home page reads, and the rows are now ordered most-clicked first to match the Popular Links ordering.

Tested with `go test ./...`.
