### PR TITLE
feat: support workload identity federation and reading auth key/ID token from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,36 @@ You will also need to specify your sqlite database file:
 golink stores its tailscale data files in a `tsnet-golink` directory inside [os.UserConfigDir].
 As long as this is on a persistent volume, the auth key only needs to be provided on first run.
 
+Instead of passing the key inline, you can have golink read it from a file with
+the `--auth-key-file` flag (or the `TS_AUTHKEY_FILE` environment variable).
+This is useful when the key is provided as a mounted secret:
+
+    golink -sqlitedb golink.db --auth-key-file /run/secrets/ts_authkey
+
 [auth key]: https://tailscale.com/kb/1085/auth-keys/
 [tag]: https://tailscale.com/kb/1068/acl-tags/
 [os.UserConfigDir]: https://pkg.go.dev/os#UserConfigDir
+
+## Workload identity federation
+
+golink supports authenticating via [workload identity federation] (WIF) instead
+of an auth key, which is convenient when running on infrastructure that can issue
+short-lived OIDC tokens (for example, a Kubernetes pod with a mounted
+ServiceAccount token).
+
+Set the OAuth client ID with `TS_CLIENT_ID` and provide an ID token. The token
+can be supplied directly via `TS_ID_TOKEN`, or read from a file with the
+`--id-token-file` flag (or `TS_ID_TOKEN_FILE` environment variable):
+
+    TS_CLIENT_ID="<client-id>" \
+      golink -sqlitedb golink.db \
+      --id-token-file /var/run/secrets/kubernetes.io/serviceaccount/token
+
+Alternatively, set `TS_AUDIENCE` (instead of an ID token) to have tsnet request a
+token from a well-known identity provider. Exactly one of an ID token or an
+audience must be provided.
+
+[workload identity federation]: https://pkg.go.dev/tailscale.com/tsnet#hdr-Authentication
 
 ## Registering as a Tailscale Service
 

--- a/golink.go
+++ b/golink.go
@@ -36,6 +36,8 @@ import (
 	"tailscale.com/client/local"
 	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/envknob"
+	// links in workload identity federation support for tsnet.
+	_ "tailscale.com/feature/identityfederation"
 	"tailscale.com/hostinfo"
 	"tailscale.com/ipn"
 	"tailscale.com/tailcfg"
@@ -72,6 +74,8 @@ var (
 	readonly          = flag.Bool("readonly", false, "start golink server in read-only mode")
 	advertiseTags     = flag.String("advertise-tags", os.Getenv("TS_ADVERTISE_TAGS"), "comma-separated list of ACL tags to advertise (e.g. tag:golink)")
 	serviceName       = flag.String("register-as-service", envknob.String("TS_SERVICE_NAME"), "register as a Tailscale Service (e.g., svc:golink); requires tagged node")
+	authKeyFile       = flag.String("auth-key-file", envknob.String("TS_AUTHKEY_FILE"), "path to a file containing the Tailscale auth key; takes precedence over TS_AUTHKEY")
+	idTokenFile       = flag.String("id-token-file", envknob.String("TS_ID_TOKEN_FILE"), "path to a file containing an ID token for workload identity federation (e.g. a mounted Kubernetes ServiceAccount token); requires TS_CLIENT_ID")
 )
 
 var stats struct {
@@ -212,6 +216,15 @@ func Run() error {
 		return err
 	}
 
+	authKey, err := readFlagFile(*authKeyFile)
+	if err != nil {
+		return fmt.Errorf("reading auth key file: %w", err)
+	}
+	idToken, err := readFlagFile(*idTokenFile)
+	if err != nil {
+		return fmt.Errorf("reading ID token file: %w", err)
+	}
+
 	// create tsNet server and wait for it to be ready & connected.
 	srv := &tsnet.Server{
 		ControlURL:    *controlURL,
@@ -220,6 +233,8 @@ func Run() error {
 		Logf:          func(format string, args ...any) {},
 		RunWebClient:  true,
 		AdvertiseTags: tags,
+		AuthKey:       authKey,
+		IDToken:       idToken,
 	}
 	if *verbose {
 		srv.Logf = log.Printf
@@ -1335,4 +1350,17 @@ func parseAdvertiseTags(s string) ([]string, error) {
 		tags = append(tags, tag)
 	}
 	return tags, nil
+}
+
+// readFlagFile returns the trimmed contents of the file at path, or "" if path
+// is empty.
+func readFlagFile(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
 }


### PR DESCRIPTION
## What

Adds two file-based credential options to golink, plus links in tsnet's workload identity federation (WIF) support.

### `--auth-key-file` / `TS_AUTHKEY_FILE` (fixes #237)
Read the Tailscale auth key from a file instead of passing it inline. Useful when the key is provided as a mounted secret.

```
golink -sqlitedb golink.db --auth-key-file /run/secrets/ts_authkey
```

### `--id-token-file` / `TS_ID_TOKEN_FILE` + WIF (fixes #238)
Authenticate via [workload identity federation](https://pkg.go.dev/tailscale.com/tsnet#hdr-Authentication) instead of an auth key. The ID token can be read from a file, which is the natural fit for a Kubernetes pod's mounted ServiceAccount token (it's a file, not an env var, and rotates over time).

```
TS_CLIENT_ID="<client-id>" \
  golink -sqlitedb golink.db \
  --id-token-file /var/run/secrets/kubernetes.io/serviceaccount/token
```

Per the tsnet docs, WIF support is not linked by default (to keep cloud-provider SDK deps out of programs that don't use it), so this PR adds a blank import of `tailscale.com/feature/identityfederation`. `TS_CLIENT_ID`, `TS_ID_TOKEN`, and `TS_AUDIENCE` continue to be honored directly by tsnet; this PR only adds the file-based ID token option and the feature link.

## Implementation notes

- Both files are read once at startup via a small `readFlagFile` helper (returns `""` for an empty path, trims trailing whitespace). This matches tsnet's behavior: the credentials are only used during initial node enrollment and ignored once state is persisted, so a single read is sufficient.
- `AuthKey` and `IDToken` are set on the `tsnet.Server`; existing `TS_AUTHKEY` behavior is unchanged when the new flags are not used.

## Testing

- `go build ./...`, `go vet ./...` clean
- `go test ./...` — all existing tests pass
- README updated to document both options