### PR TITLE
golink: set Referrer-Policy: no-referrer on all responses

### DIFF
--- a/golink.go
+++ b/golink.go
@@ -545,6 +545,13 @@ func serveHandler() http.Handler {
 	mux.Handle("/.static/", http.StripPrefix("/.", http.FileServer(http.FS(embeddedFS))))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Never send a Referer header to link destinations, which would
+		// otherwise expose the golink host (and thus the tailnet name) to
+		// external sites. Setting the policy on redirect responses also
+		// strips any referrer inherited from the page that linked to the
+		// go link.
+		w.Header().Set("Referrer-Policy", "no-referrer")
+
 		// all internal URLs begin with a leading "."; any other URL is treated as a go link.
 		// Serve go links directly without passing through the ServeMux,
 		// which sometimes modifies the request URL path, which we don't want.

--- a/golink_test.go
+++ b/golink_test.go
@@ -156,6 +156,27 @@ func TestServeGo(t *testing.T) {
 	}
 }
 
+func TestReferrerPolicy(t *testing.T) {
+	var err error
+	db, err = NewSQLiteDB(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.Save(&Link{Short: "who", Long: "http://who/"})
+
+	// all responses should ask the browser to suppress the Referer header,
+	// so that link destinations never learn the golink host.
+	for _, path := range []string{"/", "/who", "/.detail/who"} {
+		r := httptest.NewRequest("GET", path, nil)
+		w := httptest.NewRecorder()
+		serveHandler().ServeHTTP(w, r)
+
+		if got := w.Header().Get("Referrer-Policy"); got != "no-referrer" {
+			t.Errorf("GET %q: Referrer-Policy = %q; want %q", path, got, "no-referrer")
+		}
+	}
+}
+
 func TestServeSave(t *testing.T) {
 	var err error
 	db, err = NewSQLiteDB(":memory:")


### PR DESCRIPTION
Browsers send a `Referer` header when following golink redirects or when clicking links on golink's own pages (the index and `/.detail/` pages). Under the default `strict-origin-when-cross-origin` policy the destination receives the golink origin — which exposes the tailnet name (e.g. `https://go.tailXXXX.ts.net/`) to every external site a go link points at. It then shows up in places like GitHub's "Referring sites" traffic panel.

This PR sets `Referrer-Policy: no-referrer` on all responses:

- On HTML pages, it stops the browser from sending a `Referer` for outbound links.
- On 302 redirects, a `Referrer-Policy` header on the redirect response updates the referrer policy of the ongoing navigation per the [referrer-policy spec](https://w3c.github.io/webappsec-referrer-policy/#set-requests-referrer-policy-on-redirect), so any referrer inherited from the page that linked to the go link is stripped as well.

golink pages have no cross-origin resources or destinations that rely on receiving a referrer, so `no-referrer` across the board seemed like the simplest correct policy.

Includes a test asserting the header is present on redirects, golink-served HTML, and internal pages.
